### PR TITLE
Resolve client version at runtime

### DIFF
--- a/src/protocol/client-version.ts
+++ b/src/protocol/client-version.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs"
+import path from "node:path"
+import {
+  FALLBACK_CLIENT_VERSION,
+  MODEL_CACHE_TTL_MS,
+  VERSION_CACHE_FILE,
+} from "../shared.js"
+
+const INSTALL_URL = "https://cursor.com/install"
+const REMOTE_TIMEOUT_MS = 5_000
+const BUILD_RE = /^\d{4}\.\d{2}\.\d{2}-[0-9A-Za-z][0-9A-Za-z.-]*$/
+const CLIENT_VERSION_RE = /^cli-[0-9A-Za-z][0-9A-Za-z._-]*$/
+
+type VersionCache = { version: string; fetchedAt: number }
+
+let cachedResolution: Promise<string> | undefined
+
+export function resetClientVersionCache(): void {
+  cachedResolution = undefined
+}
+
+export function resolveClientVersion(): Promise<string> {
+  cachedResolution ??= resolve()
+  return cachedResolution
+}
+
+async function resolve(): Promise<string> {
+  const env = process.env.CURSOR_CLIENT_VERSION?.trim()
+  if (isClientVersion(env)) return env
+
+  const local = discoverLocalVersion()
+  if (local) return local
+
+  return (await resolveRemoteVersion()) ?? FALLBACK_CLIENT_VERSION
+}
+
+function isClientVersion(value: unknown): value is string {
+  return typeof value === "string" && CLIENT_VERSION_RE.test(value)
+}
+
+export function cursorAgentVersionsDir(): string | undefined {
+  const home = process.env.HOME || process.env.USERPROFILE
+  if (!home) return undefined
+
+  switch (process.platform) {
+    case "linux":
+    case "darwin":
+      return path.join(home, ".local", "share", "cursor-agent", "versions")
+    case "win32":
+      // ponytail: Cursor documents no Windows versions path; add it once verified.
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+export function discoverLocalVersion(
+  dir = cursorAgentVersionsDir(),
+): string | undefined {
+  if (!dir) return undefined
+
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return undefined
+  }
+
+  let newest: { name: string; mtimeMs: number } | undefined
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !BUILD_RE.test(entry.name)) continue
+    try {
+      const mtimeMs = fs.statSync(path.join(dir, entry.name)).mtimeMs
+      if (
+        !newest ||
+        mtimeMs > newest.mtimeMs ||
+        (mtimeMs === newest.mtimeMs && entry.name > newest.name)
+      ) {
+        newest = { name: entry.name, mtimeMs }
+      }
+    } catch {
+      // Directory disappeared during discovery.
+    }
+  }
+
+  return newest ? `cli-${newest.name}` : undefined
+}
+
+export function extractVersionFromInstaller(script: string): string | undefined {
+  const match = script.match(/downloads\.cursor\.com\/lab\/([^/"'\s]+)\//)
+  return match && BUILD_RE.test(match[1]) ? match[1] : undefined
+}
+
+function resolveCacheDir(): string | undefined {
+  if (process.env.CURSOR_CONFIG_DIR) return process.env.CURSOR_CONFIG_DIR
+  const home = process.env.HOME || process.env.USERPROFILE
+  if (!home) return undefined
+  return process.env.XDG_CONFIG_HOME
+    ? path.join(process.env.XDG_CONFIG_HOME, "opencode")
+    : path.join(home, ".config", "opencode")
+}
+
+function versionCachePath(): string | undefined {
+  const dir = resolveCacheDir()
+  return dir ? path.join(dir, VERSION_CACHE_FILE) : undefined
+}
+
+function readVersionCache(): VersionCache | undefined {
+  const file = versionCachePath()
+  if (!file) return undefined
+
+  try {
+    const value = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>
+    if (
+      !isClientVersion(value.version) ||
+      typeof value.fetchedAt !== "number" ||
+      !Number.isFinite(value.fetchedAt)
+    ) {
+      return undefined
+    }
+    return { version: value.version, fetchedAt: value.fetchedAt }
+  } catch {
+    return undefined
+  }
+}
+
+function writeVersionCache(cache: VersionCache): void {
+  const file = versionCachePath()
+  if (!file) return
+
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(cache, null, 2))
+  } catch {
+    // Cache writes are optional.
+  }
+}
+
+function isCacheFresh(cache: VersionCache, now = Date.now()): boolean {
+  const age = now - cache.fetchedAt
+  return age >= 0 && age < MODEL_CACHE_TTL_MS
+}
+
+async function fetchInstallerVersion(): Promise<string | undefined> {
+  const response = await fetch(INSTALL_URL, {
+    signal: AbortSignal.timeout(REMOTE_TIMEOUT_MS),
+  })
+  if (!response.ok) return undefined
+
+  const build = extractVersionFromInstaller(await response.text())
+  return build ? `cli-${build}` : undefined
+}
+
+async function refreshVersionCache(): Promise<void> {
+  const version = await fetchInstallerVersion()
+  if (version) writeVersionCache({ version, fetchedAt: Date.now() })
+}
+
+async function resolveRemoteVersion(): Promise<string | undefined> {
+  const cached = readVersionCache()
+  if (cached && isCacheFresh(cached)) {
+    void refreshVersionCache().catch(() => {})
+    return cached.version
+  }
+
+  try {
+    const version = await fetchInstallerVersion()
+    if (version) {
+      writeVersionCache({ version, fetchedAt: Date.now() })
+      return version
+    }
+  } catch {
+    // Use stale cache or the fallback below.
+  }
+
+  return cached?.version
+}

--- a/src/protocol/client-version.ts
+++ b/src/protocol/client-version.ts
@@ -46,9 +46,6 @@ export function cursorAgentVersionsDir(): string | undefined {
     case "linux":
     case "darwin":
       return path.join(home, ".local", "share", "cursor-agent", "versions")
-    case "win32":
-      // ponytail: Cursor documents no Windows versions path; add it once verified.
-      return undefined
     default:
       return undefined
   }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,7 +1,7 @@
 export const CURSOR_AGENT_HOST = "agentn.global.api5.cursor.sh"
 export const CURSOR_API_HOST = "api2.cursor.sh"
 export const CURSOR_WEBSITE_HOST = "cursor.com"
-export const CURSOR_CLIENT_VERSION = "cli-2026.06.26-7079533"
+export const FALLBACK_CLIENT_VERSION = "cli-2026.07.09-a3815c0"
 export const CURSOR_PROVIDER_ID = "cursor"
 export const TOKEN_EXPIRY_THRESHOLD_S = 300
 
@@ -10,6 +10,7 @@ export const AVAILABLE_MODELS_PATH = "/aiserver.v1.AiService/AvailableModels"
 
 export const MODEL_CACHE_FILE = "cursor-models.json"
 export const MODEL_CACHE_TTL_MS = 86_400_000
+export const VERSION_CACHE_FILE = "cursor-client-version.json"
 
 export const CONTENT_TYPE_CONNECT_PROTO = "application/connect+proto"
 export const CONNECT_PROTOCOL_VERSION = "1"

--- a/src/transport/connect.ts
+++ b/src/transport/connect.ts
@@ -1,4 +1,4 @@
-import { CURSOR_API_HOST, CURSOR_AGENT_HOST, CURSOR_CLIENT_VERSION, CONNECT_PROTOCOL_VERSION } from "../shared.js"
+import { CURSOR_API_HOST, CURSOR_AGENT_HOST, FALLBACK_CLIENT_VERSION, CONNECT_PROTOCOL_VERSION } from "../shared.js"
 import { encodeFrame, streamFrames } from "../protocol/framing.js"
 import { createCursorChecksumHeader } from "../protocol/checksum.js"
 import { getDeviceIds } from "../protocol/device-id.js"
@@ -38,7 +38,7 @@ function buildBaseHeaders(token: string, extra?: Record<string, string>): Record
     authorization: `Bearer ${token}`,
     "connect-protocol-version": CONNECT_PROTOCOL_VERSION,
     "x-cursor-client-type": "cli",
-    "x-cursor-client-version": CURSOR_CLIENT_VERSION,
+    "x-cursor-client-version": FALLBACK_CLIENT_VERSION,
     "x-cursor-checksum": createCursorChecksumHeader(machineId, macMachineId),
     "x-ghost-mode": "true",
     "x-request-id": crypto.randomUUID(),

--- a/src/transport/connect.ts
+++ b/src/transport/connect.ts
@@ -1,7 +1,8 @@
-import { CURSOR_API_HOST, CURSOR_AGENT_HOST, FALLBACK_CLIENT_VERSION, CONNECT_PROTOCOL_VERSION } from "../shared.js"
+import { CURSOR_API_HOST, CURSOR_AGENT_HOST, CONNECT_PROTOCOL_VERSION } from "../shared.js"
 import { encodeFrame, streamFrames } from "../protocol/framing.js"
 import { createCursorChecksumHeader } from "../protocol/checksum.js"
 import { getDeviceIds } from "../protocol/device-id.js"
+import { resolveClientVersion } from "../protocol/client-version.js"
 import http2 from "node:http2"
 import fs from "node:fs"
 
@@ -32,13 +33,17 @@ export function trace(msg: string): void {
 }
 trace("connect.ts module loaded")
 
-function buildBaseHeaders(token: string, extra?: Record<string, string>): Record<string, string> {
+export function buildBaseHeaders(
+  token: string,
+  clientVersion: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
   const { machineId, macMachineId } = getDeviceIds()
   return {
     authorization: `Bearer ${token}`,
     "connect-protocol-version": CONNECT_PROTOCOL_VERSION,
     "x-cursor-client-type": "cli",
-    "x-cursor-client-version": FALLBACK_CLIENT_VERSION,
+    "x-cursor-client-version": clientVersion,
     "x-cursor-checksum": createCursorChecksumHeader(machineId, macMachineId),
     "x-ghost-mode": "true",
     "x-request-id": crypto.randomUUID(),
@@ -54,7 +59,8 @@ export async function unaryAvailableModels(
 ): Promise<Record<string, unknown>> {
   const base = options.baseURL ?? API_BASE
   const url = `${base}/aiserver.v1.AiService/AvailableModels`
-  const headers = buildBaseHeaders(token, options.headers)
+  const clientVersion = await resolveClientVersion()
+  const headers = buildBaseHeaders(token, clientVersion, options.headers)
 
   const res = await fetch(url, {
     method: "POST",
@@ -156,9 +162,12 @@ export async function bidiRunStream(
   token: string,
   options: { signal?: AbortSignal; baseURL?: string; headers?: Record<string, string> } = {},
 ): Promise<BidiStream> {
-  const session = await getSession(options.baseURL)
+  const [session, clientVersion] = await Promise.all([
+    getSession(options.baseURL),
+    resolveClientVersion(),
+  ])
   const headers = {
-    ...buildBaseHeaders(token, options.headers),
+    ...buildBaseHeaders(token, clientVersion, options.headers),
     ":method": "POST",
     ":path": "/agent.v1.AgentService/Run",
     "content-type": "application/connect+proto",

--- a/test/client-version.test.ts
+++ b/test/client-version.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { FALLBACK_CLIENT_VERSION } from "../src/shared.js"
+import {
+  cursorAgentVersionsDir,
+  discoverLocalVersion,
+  extractVersionFromInstaller,
+  resetClientVersionCache,
+  resolveClientVersion,
+} from "../src/protocol/client-version.js"
+
+const INSTALLER_FIXTURE = `
+DOWNLOAD_URL="https://downloads.cursor.com/lab/2026.07.09-a3815c0/\${OS}/\${ARCH}/agent-cli-package.tar.gz"
+FINAL_DIR="$HOME/.local/share/cursor-agent/versions/2026.07.09-a3815c0"
+`
+
+const ENV_KEYS = [
+  "CURSOR_CLIENT_VERSION",
+  "CURSOR_CONFIG_DIR",
+  "HOME",
+  "USERPROFILE",
+  "XDG_CONFIG_HOME",
+] as const
+
+let tmp: string
+let realFetch: typeof globalThis.fetch
+let savedEnv: Map<string, string | undefined>
+
+function writeVersionCache(version: unknown, fetchedAt: unknown): void {
+  fs.writeFileSync(
+    path.join(tmp, "cursor-client-version.json"),
+    JSON.stringify({ version, fetchedAt }),
+  )
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "client-version-test-"))
+  realFetch = globalThis.fetch
+  savedEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]))
+  for (const key of ENV_KEYS) delete process.env[key]
+  process.env.CURSOR_CONFIG_DIR = tmp
+  process.env.HOME = tmp
+  process.env.USERPROFILE = tmp
+  resetClientVersionCache()
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  resetClientVersionCache()
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+describe("extractVersionFromInstaller", () => {
+  it("extracts the build from the official download URL", () => {
+    expect(extractVersionFromInstaller(INSTALLER_FIXTURE)).toBe("2026.07.09-a3815c0")
+  })
+
+  it("accepts the irregular timestamp build form", () => {
+    const script = "https://downloads.cursor.com/lab/2026.06.24-00-45-58-9f61de7/linux/x64/file"
+    expect(extractVersionFromInstaller(script)).toBe("2026.06.24-00-45-58-9f61de7")
+  })
+
+  it("rejects a malformed build segment", () => {
+    const script = "https://downloads.cursor.com/lab/not-a-build/linux/x64/file"
+    expect(extractVersionFromInstaller(script)).toBeUndefined()
+  })
+})
+
+describe("discoverLocalVersion", () => {
+  it("returns the newest valid build directory by mtime", () => {
+    const older = path.join(tmp, "2026.06.26-7079533")
+    const newer = path.join(tmp, "2026.07.09-a3815c0")
+    fs.mkdirSync(older)
+    fs.mkdirSync(newer)
+    const past = new Date(Date.now() - 60_000)
+    fs.utimesSync(older, past, past)
+    expect(discoverLocalVersion(tmp)).toBe("cli-2026.07.09-a3815c0")
+  })
+
+  it("ignores files, hidden directories, and invalid build names", () => {
+    fs.writeFileSync(path.join(tmp, "2026.07.10-not-a-directory"), "")
+    fs.mkdirSync(path.join(tmp, ".tmp-2026.07.10-deadbeef"))
+    fs.mkdirSync(path.join(tmp, "garbage"))
+    expect(discoverLocalVersion(tmp)).toBeUndefined()
+  })
+
+  it("returns undefined for a missing directory", () => {
+    expect(discoverLocalVersion(path.join(tmp, "missing"))).toBeUndefined()
+  })
+})
+
+describe("resolveClientVersion", () => {
+  it("prefers a valid environment override without touching lower sources", async () => {
+    process.env.CURSOR_CLIENT_VERSION = "  cli-override-123  "
+    const versionsDir = cursorAgentVersionsDir()
+    if (versionsDir) fs.mkdirSync(path.join(versionsDir, "2026.07.09-local"), { recursive: true })
+    let fetchCalls = 0
+    globalThis.fetch = (async () => {
+      fetchCalls += 1
+      return new Response(INSTALLER_FIXTURE, { status: 200 })
+    }) as typeof fetch
+
+    expect(await resolveClientVersion()).toBe("cli-override-123")
+    expect(fetchCalls).toBe(0)
+  })
+
+  it("ignores an invalid environment override", async () => {
+    process.env.CURSOR_CLIENT_VERSION = "bad\r\nheader"
+    globalThis.fetch = (async () =>
+      new Response(INSTALLER_FIXTURE, { status: 200 })) as typeof fetch
+    expect(await resolveClientVersion()).toBe("cli-2026.07.09-a3815c0")
+  })
+
+  it("uses the remote installer with no environment or local build", async () => {
+    globalThis.fetch = (async () =>
+      new Response(INSTALLER_FIXTURE, { status: 200 })) as typeof fetch
+    expect(await resolveClientVersion()).toBe("cli-2026.07.09-a3815c0")
+  })
+
+  it("returns a fresh cache entry and starts background refresh", async () => {
+    writeVersionCache("cli-cached-123", Date.now())
+    let fetchCalls = 0
+    globalThis.fetch = (async () => {
+      fetchCalls += 1
+      return new Response(INSTALLER_FIXTURE, { status: 200 })
+    }) as typeof fetch
+
+    expect(await resolveClientVersion()).toBe("cli-cached-123")
+    expect(fetchCalls).toBe(1)
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  })
+
+  it("serves an expired cache entry when refresh fails", async () => {
+    writeVersionCache("cli-cached-999", 0)
+    globalThis.fetch = (async () => { throw new Error("offline") }) as typeof fetch
+    expect(await resolveClientVersion()).toBe("cli-cached-999")
+  })
+
+  it("ignores malformed cache data and uses the fallback offline", async () => {
+    writeVersionCache("not-a-client-version", "yesterday")
+    globalThis.fetch = (async () => { throw new Error("offline") }) as typeof fetch
+    expect(await resolveClientVersion()).toBe(FALLBACK_CLIENT_VERSION)
+  })
+
+  it("memoizes the full chain for the process lifetime", async () => {
+    let fetchCalls = 0
+    globalThis.fetch = (async () => {
+      fetchCalls += 1
+      return new Response(INSTALLER_FIXTURE, { status: 200 })
+    }) as typeof fetch
+
+    expect(await resolveClientVersion()).toBe("cli-2026.07.09-a3815c0")
+    expect(await resolveClientVersion()).toBe("cli-2026.07.09-a3815c0")
+    expect(fetchCalls).toBe(1)
+  })
+})

--- a/test/connect-origin.test.ts
+++ b/test/connect-origin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { resolveAgentOrigin } from "../src/transport/connect.js"
+import { buildBaseHeaders, resolveAgentOrigin } from "../src/transport/connect.js"
 import { CURSOR_AGENT_HOST } from "../src/shared.js"
 
 describe("resolveAgentOrigin", () => {
@@ -18,5 +18,12 @@ describe("resolveAgentOrigin", () => {
     const a = resolveAgentOrigin()
     const b = resolveAgentOrigin("https://127.0.0.1:8443")
     expect(a).not.toBe(b)
+  })
+})
+
+describe("buildBaseHeaders", () => {
+  it("uses the supplied client version", () => {
+    const headers = buildBaseHeaders("token", "cli-test-123")
+    expect(headers["x-cursor-client-version"]).toBe("cli-test-123")
   })
 })


### PR DESCRIPTION
## Problem

The provider sends a hardcoded `x-cursor-client-version` value. On 2026-07-14, Cursor's live endpoint required the `cli-` prefix and did not check build currency. The pinned value passed that gate. A future currency check would force users to wait for a provider release.

## Change

- Resolve the version from `CURSOR_CLIENT_VERSION`, installed cursor-agent builds, Cursor's installer, then the fallback constant.
- Validate values before using them as request headers.
- Cache installer results for 24 hours and serve stale cache when refresh fails.
- Pass the resolved version to model discovery and Run requests.

The resolver aborts installer requests after five seconds. Linux and macOS use `~/.local/share/cursor-agent/versions/` for local discovery. Windows uses the environment, remote, cache, and fallback paths until Cursor documents a local versions directory.

## Follow-up

Live endpoint checks accepted requests without checksum and device-id headers. This PR leaves those headers unchanged; I can send that cleanup if useful.

## Test plan

- `bun run typecheck`
- `bun test` (214 pass)
- `bun run build`
