### PR TITLE
fix(plugin): cache models under ~/.cache/opencode and refill when auth exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Choose the **cursor** provider, then one of:
 | **Cursor account (browser login)** | PKCE OAuth — opens cursor.com to sign in |
 | **API key** | Paste a key from [cursor.com/settings](https://cursor.com/settings) (`sk-...`) |
 
-After login, the plugin fetches your available models and writes them to `cursor-models.json` (OpenCode config directory, or `CURSOR_CONFIG_DIR` if set).
+After login, the plugin fetches your available models and writes them to `~/.cache/opencode/cursor-models.json` (or `$XDG_CACHE_HOME/opencode/` when set).
 
 ### Select a model
 
@@ -132,11 +132,11 @@ Pass either `accessToken` (JWT from OAuth or key exchange) or `apiKey` (raw `sk-
 
 | Variable | Description |
 |----------|-------------|
-| `CURSOR_CONFIG_DIR` | Override directory for `cursor-models.json` cache (defaults to the OpenCode directory passed into the plugin) |
 | `CURSOR_WEBSITE_URL` | Override OAuth login base URL (default `https://cursor.com`) |
 | `CURSOR_API_BASE_URL` | Override API base for auth and model discovery (default `https://api2.cursor.sh`) |
 | `CURSOR_PROVIDER_DEBUG` | Set to `1` or `true` to enable wire-level debug logging |
 | `CURSOR_PROVIDER_DEBUG_FILE` | Debug log path (default `/tmp/cursor-provider-debug.log`) |
+| `XDG_CACHE_HOME` | When set, model/version caches go under `$XDG_CACHE_HOME/opencode/` instead of `~/.cache/opencode/` |
 
 `createCursor({ baseURL })` also overrides the agent Run host (default `https://agentn.global.api5.cursor.sh`).
 
@@ -190,7 +190,7 @@ OpenCode
 | No Cursor models in the picker | Run `opencode auth login`, choose **cursor**, then restart OpenCode so the plugin reloads `cursor-models.json`. Confirm `provider.cursor.npm` is the package name (or a built `file://…/dist/index.js`). |
 | Auth / 401 errors mid-session | Re-login. OAuth and exchanged API-key JWTs refresh automatically when near expiry; a revoked refresh token needs a fresh login. |
 | “Too many connections from different devices” | Device IDs are derived from stable OS identifiers (same approach as the Cursor CLI). Avoid running multiple clients that invent different machine fingerprints for the same account. |
-| Empty or stale model list | Delete `cursor-models.json` under the OpenCode config dir (or the dir set by `CURSOR_CONFIG_DIR`) and re-auth / restart so models are fetched again. Cache TTL is 24h; a failed background refresh keeps serving the previous cache. |
+| Empty or stale model list | Delete `~/.cache/opencode/cursor-models.json` (or under `$XDG_CACHE_HOME/opencode/`) and re-auth / restart so models are fetched again. Cache TTL is 24h; a failed background refresh keeps serving the previous cache. |
 | Stream hangs or HTTP/2 errors | Abort the turn and retry. The agent Run uses a bidirectional HTTP/2 stream to `agentn.global.api5.cursor.sh`; a dropped connection leaves the in-flight session unusable. |
 | Need wire-level logs | Set `CURSOR_PROVIDER_DEBUG=1` (optional `CURSOR_PROVIDER_DEBUG_FILE`, default `/tmp/cursor-provider-debug.log`) and reproduce the issue. |
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Point config at the built files with absolute `file://` URLs:
 
 ## OpenCode setup
 
-If the `cursor` provider block is omitted, the classic plugin auto-registers it on startup (as **Cursor Integration**) using this package's entry. Model entries are filled from the local cache after you authenticate.
+If the `cursor` provider block is omitted, the classic plugin auto-registers it on startup (as **Cursor Integration**) using this package's entry. Model entries come from the local cache, which is filled after auth and again on startup when the cache is empty but credentials remain.
 
 For OpenCode builds that use the Effect/Promise **v2** plugin API (`plugins` field), also load:
 
@@ -102,7 +102,15 @@ Choose the **cursor** provider, then one of:
 | **Cursor account (browser login)** | PKCE OAuth — opens cursor.com to sign in |
 | **API key** | Paste a key from [cursor.com/settings](https://cursor.com/settings) (`sk-...`) |
 
-After login, the plugin fetches your available models and writes them to `~/.cache/opencode/cursor-models.json` (or `$XDG_CACHE_HOME/opencode/` when set).
+After login, the plugin fetches your available models and writes them to `~/.cache/opencode/cursor-models.json` (or `$XDG_CACHE_HOME/opencode/` when set). On later startups, if that cache is missing or empty but Cursor auth is still present, the plugin fetches again during config load.
+
+### Paths (XDG)
+
+| Kind | Default | Override |
+|------|---------|----------|
+| Model / version **cache** | `~/.cache/opencode/` | `$XDG_CACHE_HOME/opencode/` |
+| OpenCode **auth** (`auth.json`) | `~/.local/share/opencode/` | `$XDG_DATA_HOME/opencode/` |
+| OpenCode **config** (AGENTS, skills, …) | `~/.config/opencode/` | (config dir helper; not the model cache) |
 
 ### Select a model
 
@@ -137,6 +145,7 @@ Pass either `accessToken` (JWT from OAuth or key exchange) or `apiKey` (raw `sk-
 | `CURSOR_PROVIDER_DEBUG` | Set to `1` or `true` to enable wire-level debug logging |
 | `CURSOR_PROVIDER_DEBUG_FILE` | Debug log path (default `/tmp/cursor-provider-debug.log`) |
 | `XDG_CACHE_HOME` | When set, model/version caches go under `$XDG_CACHE_HOME/opencode/` instead of `~/.cache/opencode/` |
+| `XDG_DATA_HOME` | When set, OpenCode `auth.json` is read from `$XDG_DATA_HOME/opencode/` instead of `~/.local/share/opencode/` |
 
 `createCursor({ baseURL })` also overrides the agent Run host (default `https://agentn.global.api5.cursor.sh`).
 
@@ -187,10 +196,10 @@ OpenCode
 
 | Problem | What to try |
 |---------|-------------|
-| No Cursor models in the picker | Run `opencode auth login`, choose **cursor**, then restart OpenCode so the plugin reloads `cursor-models.json`. Confirm `provider.cursor.npm` is the package name (or a built `file://…/dist/index.js`). |
+| No Cursor models in the picker | Confirm Cursor auth (`opencode auth login` → **cursor**). Restart OpenCode — if auth is present and the cache is empty, models are fetched on startup. Confirm `provider.cursor.npm` is the package name (or a built `file://…/dist/index.js`). |
 | Auth / 401 errors mid-session | Re-login. OAuth and exchanged API-key JWTs refresh automatically when near expiry; a revoked refresh token needs a fresh login. |
 | “Too many connections from different devices” | Device IDs are derived from stable OS identifiers (same approach as the Cursor CLI). Avoid running multiple clients that invent different machine fingerprints for the same account. |
-| Empty or stale model list | Delete `~/.cache/opencode/cursor-models.json` (or under `$XDG_CACHE_HOME/opencode/`) and re-auth / restart so models are fetched again. Cache TTL is 24h; a failed background refresh keeps serving the previous cache. |
+| Empty or stale model list | Delete `~/.cache/opencode/cursor-models.json` (or under `$XDG_CACHE_HOME/opencode/`) and restart OpenCode. Existing Cursor auth is enough to refill the cache; re-login only if auth itself is broken. Cache TTL is 24h; a failed background refresh keeps serving the previous cache. |
 | Stream hangs or HTTP/2 errors | Abort the turn and retry. The agent Run uses a bidirectional HTTP/2 stream to `agentn.global.api5.cursor.sh`; a dropped connection leaves the in-flight session unusable. |
 | Need wire-level logs | Set `CURSOR_PROVIDER_DEBUG=1` (optional `CURSOR_PROVIDER_DEBUG_FILE`, default `/tmp/cursor-provider-debug.log`) and reproduce the issue. |
 

--- a/src/context/auth-store.ts
+++ b/src/context/auth-store.ts
@@ -1,0 +1,82 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { opencodeGlobalDataDir } from "./paths.js"
+
+/** Mirrors OpenCode / SDK OAuth + API auth used for Cursor. `wellknown` is not wired yet. */
+export type StoredAuth =
+  | {
+      type: "oauth"
+      access: string
+      refresh: string
+      expires: number
+      accountId?: string
+      enterpriseUrl?: string
+    }
+  | {
+      type: "api"
+      key: string
+      metadata?: Record<string, string>
+    }
+
+function debugEnabled(): boolean {
+  return process.env.CURSOR_PROVIDER_DEBUG === "1" || process.env.CURSOR_PROVIDER_DEBUG === "true"
+}
+
+function debugAuthStore(message: string): void {
+  if (!debugEnabled()) return
+  console.error(`[cursor-opencode-provider] auth-store: ${message}`)
+}
+
+/**
+ * Read a provider's credentials from OpenCode's `auth.json` (XDG data dir).
+ *
+ * Honors `OPENCODE_AUTH_CONTENT` when set — same injection hook OpenCode core
+ * uses in tests / embedded runs (not an SDK export).
+ */
+export async function readStoredAuth(providerId: string): Promise<StoredAuth | undefined> {
+  if (process.env.OPENCODE_AUTH_CONTENT) {
+    try {
+      const data = JSON.parse(process.env.OPENCODE_AUTH_CONTENT) as Record<string, unknown>
+      return asStoredAuth(data[providerId])
+    } catch {
+      debugAuthStore("OPENCODE_AUTH_CONTENT is not valid JSON")
+      return undefined
+    }
+  }
+
+  const filePath = path.join(opencodeGlobalDataDir(), "auth.json")
+  try {
+    const raw = await readFile(filePath, "utf-8")
+    try {
+      const data = JSON.parse(raw) as Record<string, unknown>
+      return asStoredAuth(data[providerId])
+    } catch {
+      debugAuthStore("auth.json is not valid JSON")
+      return undefined
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code !== "ENOENT") {
+      debugAuthStore(`failed to read auth.json (${code ?? "unknown"})`)
+    }
+    return undefined
+  }
+}
+
+export function asStoredAuth(value: unknown): StoredAuth | undefined {
+  if (!value || typeof value !== "object") return undefined
+  const v = value as Record<string, unknown>
+  if (
+    v.type === "oauth" &&
+    typeof v.access === "string" &&
+    typeof v.refresh === "string" &&
+    typeof v.expires === "number"
+  ) {
+    return value as StoredAuth
+  }
+  if (v.type === "api" && typeof v.key === "string") {
+    return value as StoredAuth
+  }
+  // wellknown is intentionally rejected until resolveAccessToken supports it
+  return undefined
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,2 +1,2 @@
 export { buildRequestContext, type BuildRequestContextInput } from "./build.js"
-export { opencodeGlobalCacheDir, opencodeGlobalConfigDir } from "./paths.js"
+export { opencodeGlobalCacheDir, opencodeGlobalConfigDir, opencodeGlobalDataDir } from "./paths.js"

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,2 +1,2 @@
 export { buildRequestContext, type BuildRequestContextInput } from "./build.js"
-export { opencodeGlobalConfigDir } from "./paths.js"
+export { opencodeGlobalCacheDir, opencodeGlobalConfigDir } from "./paths.js"

--- a/src/context/paths.ts
+++ b/src/context/paths.ts
@@ -21,6 +21,18 @@ export function opencodeGlobalCacheDir(): string {
   return path.join(resolveHome(), ".cache", "opencode")
 }
 
+/**
+ * OpenCode global data dir (`~/.local/share/opencode`).
+ * Uses `$XDG_DATA_HOME/opencode` when set, otherwise `$HOME/.local/share/opencode`.
+ * Auth credentials live here in `auth.json`.
+ */
+export function opencodeGlobalDataDir(): string {
+  if (process.env.XDG_DATA_HOME) {
+    return path.join(process.env.XDG_DATA_HOME, "opencode")
+  }
+  return path.join(resolveHome(), ".local", "share", "opencode")
+}
+
 export function resolveHomeRelative(p: string): string {
   if (p.startsWith("~/")) return path.join(homedir(), p.slice(2))
   return p

--- a/src/context/paths.ts
+++ b/src/context/paths.ts
@@ -1,10 +1,24 @@
 import { homedir } from "node:os"
 import path from "node:path"
 
+function resolveHome(): string {
+  return process.env.HOME || process.env.USERPROFILE || homedir()
+}
+
 /** OpenCode global config dir (`~/.config/opencode`). */
 export function opencodeGlobalConfigDir(): string {
-  const home = process.env.HOME || process.env.USERPROFILE || homedir()
-  return path.join(home, ".config", "opencode")
+  return path.join(resolveHome(), ".config", "opencode")
+}
+
+/**
+ * OpenCode global cache dir (`~/.cache/opencode`).
+ * Uses `$XDG_CACHE_HOME/opencode` when set, otherwise `$HOME/.cache/opencode`.
+ */
+export function opencodeGlobalCacheDir(): string {
+  if (process.env.XDG_CACHE_HOME) {
+    return path.join(process.env.XDG_CACHE_HOME, "opencode")
+  }
+  return path.join(resolveHome(), ".cache", "opencode")
 }
 
 export function resolveHomeRelative(p: string): string {

--- a/src/context/paths.ts
+++ b/src/context/paths.ts
@@ -3,7 +3,8 @@ import path from "node:path"
 
 /** OpenCode global config dir (`~/.config/opencode`). */
 export function opencodeGlobalConfigDir(): string {
-  return path.join(homedir(), ".config", "opencode")
+  const home = process.env.HOME || process.env.USERPROFILE || homedir()
+  return path.join(home, ".config", "opencode")
 }
 
 export function resolveHomeRelative(p: string): string {

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -1,4 +1,3 @@
-import path from "node:path"
 import fs from "node:fs"
 import { createHash } from "node:crypto"
 import type { LanguageModelV3, LanguageModelV3CallOptions, LanguageModelV3StreamResult, LanguageModelV3GenerateResult, LanguageModelV3StreamPart, LanguageModelV3Usage, LanguageModelV3FinishReason } from "@ai-sdk/provider"
@@ -25,11 +24,12 @@ import { conversationBlobCount } from "./protocol/blob-store.js"
 import { sessionManager, type CursorSession, type Frame } from "./session.js"
 import { readCache, cacheFilePath, resolveVariantParameters, type ModelInfo } from "./models.js"
 import { buildRequestContext } from "./context/build.js"
+import { opencodeGlobalCacheDir } from "./context/paths.js"
 
 let _availableModels: ModelInfo[] | undefined
 // mtime of the cache file the last time we loaded it. Compared on each call
 // so discoverModels' background refresh is picked up without a process restart.
-let _availableModelsMtimeMs = 0
+let _availableModelsMtimeMs = -1
 
 type V3Part = LanguageModelV3StreamPart
 
@@ -342,10 +342,9 @@ export function findContinuationSession(
 }
 
 async function loadAvailableModels(): Promise<void> {
-  const configDir = resolveModelCacheDir()
-  if (!configDir) return
+  const cacheDir = opencodeGlobalCacheDir()
   try {
-    const filePath = cacheFilePath(configDir)
+    const filePath = cacheFilePath(cacheDir)
     let mtime = 0
     try {
       const stat = await fs.promises.stat(filePath)
@@ -355,21 +354,11 @@ async function loadAvailableModels(): Promise<void> {
     }
     // Re-read when the file changed (discoverModels background refresh).
     if (mtime !== _availableModelsMtimeMs) {
-      const cached = await readCache(configDir)
+      const cached = await readCache(cacheDir)
       _availableModels = cached?.models
       _availableModelsMtimeMs = mtime
     }
   } catch { /* ignore */ }
-}
-
-/** Same directory the plugin writes to (CURSOR_CONFIG_DIR, else OpenCode config). */
-function resolveModelCacheDir(): string | undefined {
-  if (process.env.CURSOR_CONFIG_DIR) return process.env.CURSOR_CONFIG_DIR
-  const home = process.env.HOME || process.env.USERPROFILE
-  if (!home) return undefined
-  return process.env.XDG_CONFIG_HOME
-    ? path.join(process.env.XDG_CONFIG_HOME, "opencode")
-    : path.join(home, ".config", "opencode")
 }
 
 /**

--- a/src/models.ts
+++ b/src/models.ts
@@ -39,12 +39,12 @@ export function isCacheFresh(cache: ModelCache, ttlMs = MODEL_CACHE_TTL_MS): boo
   return Date.now() - cache.fetchedAt < ttlMs
 }
 
-export function cacheFilePath(configDir: string): string {
-  return path.join(configDir, MODEL_CACHE_FILE)
+export function cacheFilePath(cacheDir: string): string {
+  return path.join(cacheDir, MODEL_CACHE_FILE)
 }
 
-export async function readCache(configDir: string): Promise<ModelCache | null> {
-  const filePath = cacheFilePath(configDir)
+export async function readCache(cacheDir: string): Promise<ModelCache | null> {
+  const filePath = cacheFilePath(cacheDir)
   try {
     if (!existsSync(filePath)) return null
     const data = await readFile(filePath, "utf-8")
@@ -54,8 +54,8 @@ export async function readCache(configDir: string): Promise<ModelCache | null> {
   }
 }
 
-export async function writeCache(configDir: string, cache: ModelCache): Promise<void> {
-  const filePath = cacheFilePath(configDir)
+export async function writeCache(cacheDir: string, cache: ModelCache): Promise<void> {
+  const filePath = cacheFilePath(cacheDir)
   await mkdir(path.dirname(filePath), { recursive: true })
   await writeFile(filePath, JSON.stringify(cache, null, 2), "utf-8")
 }
@@ -161,17 +161,17 @@ export async function fetchModels(
 
 export async function discoverModels(
   token: string,
-  configDir: string,
+  cacheDir: string,
   options: { baseURL?: string; headers?: Record<string, string> } = {},
 ): Promise<ModelInfo[]> {
-  const cached = await readCache(configDir)
+  const cached = await readCache(cacheDir)
 
   // Cache is fresh → return it; refresh in background
   if (cached && isCacheFresh(cached)) {
     // Background refresh (fire and forget)
     fetchModels(token, options)
       .then((models) =>
-        writeCache(configDir, { models, fetchedAt: Date.now() }),
+        writeCache(cacheDir, { models, fetchedAt: Date.now() }),
       )
       .catch(() => {
         /* background refresh failure is non-fatal */
@@ -184,7 +184,7 @@ export async function discoverModels(
     try {
       const models = await fetchModels(token, options)
       const newCache: ModelCache = { models, fetchedAt: Date.now() }
-      await writeCache(configDir, newCache)
+      await writeCache(cacheDir, newCache)
       return models
     } catch {
       return cached.models
@@ -194,6 +194,6 @@ export async function discoverModels(
   // No cache → must fetch
   const models = await fetchModels(token, options)
   const newCache: ModelCache = { models, fetchedAt: Date.now() }
-  await writeCache(configDir, newCache)
+  await writeCache(cacheDir, newCache)
   return models
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,10 @@
 import type { Hooks, PluginInput, AuthOAuthResult, Config } from "@opencode-ai/plugin"
+import type { Auth } from "@opencode-ai/sdk"
 import { CURSOR_PROVIDER_ID, CURSOR_WEBSITE_HOST, CURSOR_API_HOST } from "./shared.js"
 import { pollForTokens, exchangeApiKey, refreshAccessToken, isExpiringSoon, generatePkceParams, generatePkceChallenge, buildLoginUrl, decodeJwtPayload } from "./auth.js"
-import { readCache, discoverModels, type ModelInfo } from "./models.js"
+import { readCache, discoverModels, isCacheFresh, type ModelInfo } from "./models.js"
 import { opencodeGlobalCacheDir } from "./context/paths.js"
+import { readStoredAuth, type StoredAuth } from "./context/auth-store.js"
 
 const MODULE_URL = new URL("./index.js", import.meta.url).href
 
@@ -88,20 +90,137 @@ export function modelInfoToConfig(
   return config
 }
 
+function modelsToConfig(models: ModelInfo[]): Record<string, any> {
+  const ambiguous = thinkingSuffixBaseNames(models)
+  const out: Record<string, any> = {}
+  for (const m of models) {
+    out[m.id] = modelInfoToConfig(m, {
+      thinkingSuffix: !!m.supportsThinking && ambiguous.has(baseName(m)),
+    })
+  }
+  return out
+}
+
 export async function CursorPlugin(input: PluginInput): Promise<Hooks> {
   const cacheDir = opencodeGlobalCacheDir()
 
+  // Last access token successfully resolved in this plugin instance. Config's
+  // loadModels can only read OpenCode's durable store (auth.json /
+  // OPENCODE_AUTH_CONTENT); auth.loader gets live credentials via getAuth().
+  // Those usually match, but after a refresh where persistAuthBestEffort fails,
+  // getAuth() may still see the old credentials while we already hold a usable
+  // token here — keep it so the loader can still discover models.
+  let sessionAccessToken: string | undefined
+
+  async function persistAuth(body: Auth): Promise<void> {
+    await input.client.auth.set({
+      path: { id: CURSOR_PROVIDER_ID },
+      body,
+    })
+  }
+
+  /** Persist refreshed credentials without failing the caller that already holds a live token. */
+  async function persistAuthBestEffort(body: Auth): Promise<void> {
+    try {
+      await persistAuth(body)
+    } catch {
+      // ignore — token is still usable for this process
+    }
+  }
+
+  /**
+   * Durable credentials OpenCode stores on disk (same file getAuth() reads in
+   * the normal path). Used from `config`, which has no getAuth() callback.
+   */
+  async function authFromStore(): Promise<Auth | StoredAuth | undefined> {
+    return readStoredAuth(CURSOR_PROVIDER_ID)
+  }
+
+  /**
+   * Prefer OpenCode's live getAuth(); fall back to the durable store so loader
+   * and config share the same underlying credentials when possible.
+   */
+  async function authForLoader(
+    getAuth: () => Promise<Auth | undefined>,
+  ): Promise<Auth | StoredAuth | undefined> {
+    return (await getAuth()) ?? (await authFromStore())
+  }
+
+  async function resolveAccessToken(auth: Auth | StoredAuth): Promise<string | undefined> {
+    if (auth.type === "api") {
+      let accessToken = auth.key
+      const refreshToken = auth.metadata?.refreshToken
+      // API-key exchange returns a short-lived JWT stored as `key`. Refresh
+      // it the same way as OAuth when it is expiring / already expired.
+      if (refreshToken && isExpiringSoon(auth.key)) {
+        try {
+          const newTokens = await refreshAccessToken(refreshToken)
+          accessToken = newTokens.accessToken
+          await persistAuthBestEffort({
+            type: "api",
+            key: newTokens.accessToken,
+            metadata: {
+              ...auth.metadata,
+              refreshToken: newTokens.refreshToken,
+            },
+          })
+        } catch {
+          // refresh failed — keep the existing key; the next call may still work
+        }
+      }
+      if (accessToken) sessionAccessToken = accessToken
+      return accessToken
+    }
+
+    if (auth.type === "oauth") {
+      if (!isExpiringSoon(auth.access)) {
+        sessionAccessToken = auth.access
+        return auth.access
+      }
+      if (!auth.refresh) return undefined
+      try {
+        const newTokens = await refreshAccessToken(auth.refresh)
+        // Preserve optional OAuth fields (v2 Auth / plugin may carry these).
+        const extras = auth as { accountId?: string; enterpriseUrl?: string }
+        // Use the new token even if persisting back to OpenCode fails.
+        await persistAuthBestEffort({
+          type: "oauth",
+          access: newTokens.accessToken,
+          refresh: newTokens.refreshToken,
+          expires: decodeExpFromJwt(newTokens.accessToken),
+          ...(extras.accountId !== undefined ? { accountId: extras.accountId } : {}),
+          ...(extras.enterpriseUrl !== undefined ? { enterpriseUrl: extras.enterpriseUrl } : {}),
+        })
+        sessionAccessToken = newTokens.accessToken
+        return newTokens.accessToken
+      } catch {
+        return undefined
+      }
+    }
+
+    return undefined
+  }
+
   async function loadModels(): Promise<Record<string, any>> {
     const cached = await readCache(cacheDir)
-    if (!cached || cached.models.length === 0) return {}
-    const ambiguous = thinkingSuffixBaseNames(cached.models)
-    const models: Record<string, any> = {}
-    for (const m of cached.models) {
-      models[m.id] = modelInfoToConfig(m, {
-        thinkingSuffix: !!m.supportsThinking && ambiguous.has(baseName(m)),
-      })
+    if (!cached || cached.models.length === 0) {
+      // Config runs before auth.loader and has no getAuth(); read the durable
+      // store (normally the same source getAuth() uses).
+      const auth = await authFromStore()
+      if (auth) {
+        const accessToken = await resolveAccessToken(auth)
+        if (accessToken) {
+          try {
+            const models = await discoverModels(accessToken, cacheDir)
+            return modelsToConfig(models)
+          } catch {
+            // discovery failed — leave the list empty
+          }
+        }
+      }
+      return {}
     }
-    return models
+    return modelsToConfig(cached.models)
   }
 
   return {
@@ -188,58 +307,20 @@ export async function CursorPlugin(input: PluginInput): Promise<Hooks> {
         },
       ],
       async loader(getAuth) {
-        const auth = await getAuth()
-        if (!auth) return {}
-
-        let accessToken: string | undefined
-
-        if (auth.type === "api") {
-          accessToken = auth.key
-          const refreshToken = auth.metadata?.refreshToken
-          // API-key exchange returns a short-lived JWT stored as `key`. Refresh
-          // it the same way as OAuth when it is expiring / already expired.
-          if (refreshToken && isExpiringSoon(auth.key)) {
-            try {
-              const newTokens = await refreshAccessToken(refreshToken)
-              await input.client.auth.set({
-                path: { id: CURSOR_PROVIDER_ID },
-                body: {
-                  type: "api",
-                  key: newTokens.accessToken,
-                  metadata: { refreshToken: newTokens.refreshToken },
-                },
-              })
-              accessToken = newTokens.accessToken
-            } catch {
-              // refresh failed — keep the existing key; the next call may still work
-            }
-          }
-        } else if (auth.type === "oauth") {
-          if (!isExpiringSoon(auth.access)) {
-            accessToken = auth.access
-          } else if (auth.refresh) {
-            try {
-              const newTokens = await refreshAccessToken(auth.refresh)
-              await input.client.auth.set({
-                path: { id: CURSOR_PROVIDER_ID },
-                body: {
-                  type: "oauth",
-                  access: newTokens.accessToken,
-                  refresh: newTokens.refreshToken,
-                  expires: decodeExpFromJwt(newTokens.accessToken),
-                },
-              })
-              accessToken = newTokens.accessToken
-            } catch {
-              // refresh failed
-            }
-          }
-        }
-
+        const auth = await authForLoader(getAuth as () => Promise<Auth | undefined>)
+        // Prefer credentials from getAuth/store; if refresh already succeeded in
+        // loadModels but persist failed, fall back to the in-memory session token.
+        const accessToken =
+          (auth ? await resolveAccessToken(auth) : undefined) ?? sessionAccessToken
         if (accessToken) {
-          // Use discoverModels so we respect TTL / serve-stale semantics and
-          // write through the same cache path language-model reads.
-          discoverModels(accessToken, cacheDir).catch(() => { /* non-fatal */ })
+          // Skip when config already filled a fresh cache (avoids a second
+          // AvailableModels round-trip + background refresh on cold start).
+          const cached = await readCache(cacheDir)
+          if (!cached || cached.models.length === 0 || !isCacheFresh(cached)) {
+            // Await so an empty/missing cache is written before the loader returns
+            // (fire-and-forget often loses the race on short-lived CLI commands).
+            await discoverModels(accessToken, cacheDir).catch(() => { /* non-fatal */ })
+          }
         }
 
         return {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,8 @@
 import type { Hooks, PluginInput, AuthOAuthResult, Config } from "@opencode-ai/plugin"
 import { CURSOR_PROVIDER_ID, CURSOR_WEBSITE_HOST, CURSOR_API_HOST } from "./shared.js"
 import { pollForTokens, exchangeApiKey, refreshAccessToken, isExpiringSoon, generatePkceParams, generatePkceChallenge, buildLoginUrl, decodeJwtPayload } from "./auth.js"
-import { readCache, writeCache, discoverModels, type ModelInfo } from "./models.js"
-import { opencodeGlobalConfigDir } from "./context/paths.js"
+import { readCache, discoverModels, type ModelInfo } from "./models.js"
+import { opencodeGlobalCacheDir } from "./context/paths.js"
 
 const MODULE_URL = new URL("./index.js", import.meta.url).href
 
@@ -89,16 +89,10 @@ export function modelInfoToConfig(
 }
 
 export async function CursorPlugin(input: PluginInput): Promise<Hooks> {
-  const configDir = process.env.CURSOR_CONFIG_DIR || opencodeGlobalConfigDir()
+  const cacheDir = opencodeGlobalCacheDir()
 
   async function loadModels(): Promise<Record<string, any>> {
-    let cached = await readCache(configDir)
-    if (!cached && !process.env.CURSOR_CONFIG_DIR && input.directory !== configDir) {
-      // Migrate caches written to the project directory by earlier versions
-      // to the global OpenCode config directory, where language-model.ts reads.
-      cached = await readCache(input.directory)
-      if (cached) await writeCache(configDir, cached).catch(() => {})
-    }
+    const cached = await readCache(cacheDir)
     if (!cached || cached.models.length === 0) return {}
     const ambiguous = thinkingSuffixBaseNames(cached.models)
     const models: Record<string, any> = {}
@@ -245,7 +239,7 @@ export async function CursorPlugin(input: PluginInput): Promise<Hooks> {
         if (accessToken) {
           // Use discoverModels so we respect TTL / serve-stale semantics and
           // write through the same cache path language-model reads.
-          discoverModels(accessToken, configDir).catch(() => { /* non-fatal */ })
+          discoverModels(accessToken, cacheDir).catch(() => { /* non-fatal */ })
         }
 
         return {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,6 +2,7 @@ import type { Hooks, PluginInput, AuthOAuthResult, Config } from "@opencode-ai/p
 import { CURSOR_PROVIDER_ID, CURSOR_WEBSITE_HOST, CURSOR_API_HOST } from "./shared.js"
 import { pollForTokens, exchangeApiKey, refreshAccessToken, isExpiringSoon, generatePkceParams, generatePkceChallenge, buildLoginUrl, decodeJwtPayload } from "./auth.js"
 import { readCache, writeCache, discoverModels, type ModelInfo } from "./models.js"
+import { opencodeGlobalConfigDir } from "./context/paths.js"
 
 const MODULE_URL = new URL("./index.js", import.meta.url).href
 
@@ -88,10 +89,16 @@ export function modelInfoToConfig(
 }
 
 export async function CursorPlugin(input: PluginInput): Promise<Hooks> {
-  const configDir = process.env.CURSOR_CONFIG_DIR || input.directory
+  const configDir = process.env.CURSOR_CONFIG_DIR || opencodeGlobalConfigDir()
 
   async function loadModels(): Promise<Record<string, any>> {
-    const cached = await readCache(configDir)
+    let cached = await readCache(configDir)
+    if (!cached && !process.env.CURSOR_CONFIG_DIR && input.directory !== configDir) {
+      // Migrate caches written to the project directory by earlier versions
+      // to the global OpenCode config directory, where language-model.ts reads.
+      cached = await readCache(input.directory)
+      if (cached) await writeCache(configDir, cached).catch(() => {})
+    }
     if (!cached || cached.models.length === 0) return {}
     const ambiguous = thinkingSuffixBaseNames(cached.models)
     const models: Record<string, any> = {}

--- a/src/protocol/client-version.ts
+++ b/src/protocol/client-version.ts
@@ -5,6 +5,7 @@ import {
   MODEL_CACHE_TTL_MS,
   VERSION_CACHE_FILE,
 } from "../shared.js"
+import { opencodeGlobalCacheDir } from "../context/paths.js"
 
 const INSTALL_URL = "https://cursor.com/install"
 const REMOTE_TIMEOUT_MS = 5_000
@@ -88,23 +89,12 @@ export function extractVersionFromInstaller(script: string): string | undefined 
   return match && BUILD_RE.test(match[1]) ? match[1] : undefined
 }
 
-function resolveCacheDir(): string | undefined {
-  if (process.env.CURSOR_CONFIG_DIR) return process.env.CURSOR_CONFIG_DIR
-  const home = process.env.HOME || process.env.USERPROFILE
-  if (!home) return undefined
-  return process.env.XDG_CONFIG_HOME
-    ? path.join(process.env.XDG_CONFIG_HOME, "opencode")
-    : path.join(home, ".config", "opencode")
-}
-
-function versionCachePath(): string | undefined {
-  const dir = resolveCacheDir()
-  return dir ? path.join(dir, VERSION_CACHE_FILE) : undefined
+function versionCachePath(): string {
+  return path.join(opencodeGlobalCacheDir(), VERSION_CACHE_FILE)
 }
 
 function readVersionCache(): VersionCache | undefined {
   const file = versionCachePath()
-  if (!file) return undefined
 
   try {
     const value = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>
@@ -123,7 +113,6 @@ function readVersionCache(): VersionCache | undefined {
 
 function writeVersionCache(cache: VersionCache): void {
   const file = versionCachePath()
-  if (!file) return
 
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true })

--- a/test/auth-store.test.ts
+++ b/test/auth-store.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdir, writeFile, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { asStoredAuth, readStoredAuth } from "../src/context/auth-store.js"
+
+const originalHome = process.env.HOME
+const originalXdgData = process.env.XDG_DATA_HOME
+const originalAuthContent = process.env.OPENCODE_AUTH_CONTENT
+const originalDebug = process.env.CURSOR_PROVIDER_DEBUG
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalXdgData === undefined) delete process.env.XDG_DATA_HOME
+  else process.env.XDG_DATA_HOME = originalXdgData
+  if (originalAuthContent === undefined) delete process.env.OPENCODE_AUTH_CONTENT
+  else process.env.OPENCODE_AUTH_CONTENT = originalAuthContent
+  if (originalDebug === undefined) delete process.env.CURSOR_PROVIDER_DEBUG
+  else process.env.CURSOR_PROVIDER_DEBUG = originalDebug
+})
+
+describe("readStoredAuth", () => {
+  it("reads cursor credentials from auth.json under the data dir", async () => {
+    const fakeHome = path.join(os.tmpdir(), `auth-store-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
+    const dataDir = path.join(fakeHome, ".local", "share", "opencode")
+    await mkdir(dataDir, { recursive: true })
+    await writeFile(
+      path.join(dataDir, "auth.json"),
+      JSON.stringify({
+        cursor: { type: "oauth", access: "tok", refresh: "ref", expires: Date.now() + 60_000 },
+      }),
+    )
+
+    try {
+      const auth = await readStoredAuth("cursor")
+      expect(auth).toEqual({
+        type: "oauth",
+        access: "tok",
+        refresh: "ref",
+        expires: expect.any(Number),
+      })
+    } finally {
+      await rm(fakeHome, { recursive: true, force: true })
+    }
+  })
+
+  it("prefers OPENCODE_AUTH_CONTENT when set", async () => {
+    process.env.OPENCODE_AUTH_CONTENT = JSON.stringify({
+      cursor: { type: "api", key: "from-env" },
+    })
+    expect(await readStoredAuth("cursor")).toEqual({ type: "api", key: "from-env" })
+  })
+
+  it("returns undefined when missing", async () => {
+    const fakeHome = path.join(os.tmpdir(), `auth-store-miss-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
+    expect(await readStoredAuth("cursor")).toBeUndefined()
+    await rm(fakeHome, { recursive: true, force: true })
+  })
+
+  it("returns undefined for invalid JSON without throwing", async () => {
+    const fakeHome = path.join(os.tmpdir(), `auth-store-badjson-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
+    const dataDir = path.join(fakeHome, ".local", "share", "opencode")
+    await mkdir(dataDir, { recursive: true })
+    await writeFile(path.join(dataDir, "auth.json"), "{not-json")
+
+    try {
+      expect(await readStoredAuth("cursor")).toBeUndefined()
+    } finally {
+      await rm(fakeHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns undefined for empty cursor entry", async () => {
+    const fakeHome = path.join(os.tmpdir(), `auth-store-empty-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
+    const dataDir = path.join(fakeHome, ".local", "share", "opencode")
+    await mkdir(dataDir, { recursive: true })
+    await writeFile(path.join(dataDir, "auth.json"), JSON.stringify({ cursor: {} }))
+
+    try {
+      expect(await readStoredAuth("cursor")).toBeUndefined()
+    } finally {
+      await rm(fakeHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns undefined for oauth missing access", async () => {
+    const fakeHome = path.join(os.tmpdir(), `auth-store-noaccess-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
+    const dataDir = path.join(fakeHome, ".local", "share", "opencode")
+    await mkdir(dataDir, { recursive: true })
+    await writeFile(
+      path.join(dataDir, "auth.json"),
+      JSON.stringify({
+        cursor: { type: "oauth", refresh: "ref", expires: Date.now() },
+      }),
+    )
+
+    try {
+      expect(await readStoredAuth("cursor")).toBeUndefined()
+    } finally {
+      await rm(fakeHome, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("asStoredAuth", () => {
+  it("rejects wellknown until it is wired through resolveAccessToken", () => {
+    expect(
+      asStoredAuth({ type: "wellknown", key: "k", token: "t" }),
+    ).toBeUndefined()
+  })
+})

--- a/test/client-version.test.ts
+++ b/test/client-version.test.ts
@@ -18,9 +18,9 @@ FINAL_DIR="$HOME/.local/share/cursor-agent/versions/2026.07.09-a3815c0"
 
 const ENV_KEYS = [
   "CURSOR_CLIENT_VERSION",
-  "CURSOR_CONFIG_DIR",
   "HOME",
   "USERPROFILE",
+  "XDG_CACHE_HOME",
   "XDG_CONFIG_HOME",
 ] as const
 
@@ -28,11 +28,14 @@ let tmp: string
 let realFetch: typeof globalThis.fetch
 let savedEnv: Map<string, string | undefined>
 
+function versionCacheFile(): string {
+  return path.join(tmp, ".cache", "opencode", "cursor-client-version.json")
+}
+
 function writeVersionCache(version: unknown, fetchedAt: unknown): void {
-  fs.writeFileSync(
-    path.join(tmp, "cursor-client-version.json"),
-    JSON.stringify({ version, fetchedAt }),
-  )
+  const file = versionCacheFile()
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, JSON.stringify({ version, fetchedAt }))
 }
 
 beforeEach(() => {
@@ -40,7 +43,6 @@ beforeEach(() => {
   realFetch = globalThis.fetch
   savedEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]))
   for (const key of ENV_KEYS) delete process.env[key]
-  process.env.CURSOR_CONFIG_DIR = tmp
   process.env.HOME = tmp
   process.env.USERPROFILE = tmp
   resetClientVersionCache()

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,15 +1,25 @@
 import { afterEach, describe, expect, it } from "bun:test"
 import path from "node:path"
-import { opencodeGlobalCacheDir, opencodeGlobalConfigDir } from "../src/context/paths.js"
+import {
+  opencodeGlobalCacheDir,
+  opencodeGlobalConfigDir,
+  opencodeGlobalDataDir,
+} from "../src/context/paths.js"
 
 const originalHome = process.env.HOME
+const originalUserProfile = process.env.USERPROFILE
 const originalXdgCache = process.env.XDG_CACHE_HOME
+const originalXdgData = process.env.XDG_DATA_HOME
 
 afterEach(() => {
   if (originalHome === undefined) delete process.env.HOME
   else process.env.HOME = originalHome
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE
+  else process.env.USERPROFILE = originalUserProfile
   if (originalXdgCache === undefined) delete process.env.XDG_CACHE_HOME
   else process.env.XDG_CACHE_HOME = originalXdgCache
+  if (originalXdgData === undefined) delete process.env.XDG_DATA_HOME
+  else process.env.XDG_DATA_HOME = originalXdgData
 })
 
 describe("opencodeGlobalCacheDir", () => {
@@ -24,11 +34,32 @@ describe("opencodeGlobalCacheDir", () => {
     process.env.XDG_CACHE_HOME = "/tmp/xdg-cache"
     expect(opencodeGlobalCacheDir()).toBe(path.join("/tmp/xdg-cache", "opencode"))
   })
+
+  it("falls back to USERPROFILE when HOME is unset", () => {
+    delete process.env.HOME
+    process.env.USERPROFILE = "/tmp/win-home"
+    delete process.env.XDG_CACHE_HOME
+    expect(opencodeGlobalCacheDir()).toBe(path.join("/tmp/win-home", ".cache", "opencode"))
+  })
 })
 
 describe("opencodeGlobalConfigDir", () => {
   it("stays under $HOME/.config/opencode", () => {
     process.env.HOME = "/tmp/fake-home"
     expect(opencodeGlobalConfigDir()).toBe(path.join("/tmp/fake-home", ".config", "opencode"))
+  })
+})
+
+describe("opencodeGlobalDataDir", () => {
+  it("defaults to $HOME/.local/share/opencode", () => {
+    process.env.HOME = "/tmp/fake-home"
+    delete process.env.XDG_DATA_HOME
+    expect(opencodeGlobalDataDir()).toBe(path.join("/tmp/fake-home", ".local", "share", "opencode"))
+  })
+
+  it("uses $XDG_DATA_HOME/opencode when set", () => {
+    process.env.HOME = "/tmp/fake-home"
+    process.env.XDG_DATA_HOME = "/tmp/xdg-data"
+    expect(opencodeGlobalDataDir()).toBe(path.join("/tmp/xdg-data", "opencode"))
   })
 })

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import path from "node:path"
+import { opencodeGlobalCacheDir, opencodeGlobalConfigDir } from "../src/context/paths.js"
+
+const originalHome = process.env.HOME
+const originalXdgCache = process.env.XDG_CACHE_HOME
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalXdgCache === undefined) delete process.env.XDG_CACHE_HOME
+  else process.env.XDG_CACHE_HOME = originalXdgCache
+})
+
+describe("opencodeGlobalCacheDir", () => {
+  it("defaults to $HOME/.cache/opencode", () => {
+    process.env.HOME = "/tmp/fake-home"
+    delete process.env.XDG_CACHE_HOME
+    expect(opencodeGlobalCacheDir()).toBe(path.join("/tmp/fake-home", ".cache", "opencode"))
+  })
+
+  it("uses $XDG_CACHE_HOME/opencode when set", () => {
+    process.env.HOME = "/tmp/fake-home"
+    process.env.XDG_CACHE_HOME = "/tmp/xdg-cache"
+    expect(opencodeGlobalCacheDir()).toBe(path.join("/tmp/xdg-cache", "opencode"))
+  })
+})
+
+describe("opencodeGlobalConfigDir", () => {
+  it("stays under $HOME/.config/opencode", () => {
+    process.env.HOME = "/tmp/fake-home"
+    expect(opencodeGlobalConfigDir()).toBe(path.join("/tmp/fake-home", ".config", "opencode"))
+  })
+})

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -3,7 +3,7 @@ import { mkdir, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { CursorPlugin, modelInfoToConfig, thinkingSuffixBaseNames } from "../src/plugin.js"
-import { readCache, writeCache, type ModelInfo } from "../src/models.js"
+import { writeCache, type ModelInfo } from "../src/models.js"
 
 // Characters safeLabel must remove from emitted names/keys (issue #2).
 const INVALID = new RegExp("[()<>&\"'`]")
@@ -116,25 +116,25 @@ describe("modelInfoToConfig", () => {
 })
 
 const originalHome = process.env.HOME
-const originalXdg = process.env.XDG_CONFIG_HOME
+const originalXdgCache = process.env.XDG_CACHE_HOME
 
 afterEach(() => {
   if (originalHome === undefined) delete process.env.HOME
   else process.env.HOME = originalHome
-  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME
-  else process.env.XDG_CONFIG_HOME = originalXdg
+  if (originalXdgCache === undefined) delete process.env.XDG_CACHE_HOME
+  else process.env.XDG_CACHE_HOME = originalXdgCache
 })
 
 describe("CursorPlugin config hook", () => {
-  it("loads cached models from the global OpenCode config dir, not input.directory", async () => {
+  it("loads cached models from ~/.cache/opencode, not input.directory", async () => {
     const fakeHome = path.join(os.tmpdir(), `cursor-plugin-test-${process.pid}-${Date.now()}`)
     process.env.HOME = fakeHome
-    delete process.env.XDG_CONFIG_HOME
+    delete process.env.XDG_CACHE_HOME
     const projectDir = path.join(fakeHome, "project")
-    const globalDir = path.join(fakeHome, ".config", "opencode")
-    await mkdir(globalDir, { recursive: true })
+    const cacheDir = path.join(fakeHome, ".cache", "opencode")
+    await mkdir(cacheDir, { recursive: true })
     await mkdir(projectDir, { recursive: true })
-    await writeCache(globalDir, {
+    await writeCache(cacheDir, {
       fetchedAt: Date.now(),
       models: [{ id: "cursor-test-model", variants: [] }],
     })
@@ -150,16 +150,18 @@ describe("CursorPlugin config hook", () => {
     }
   })
 
-  it("migrates a project-scoped model cache into the global config dir", async () => {
+  it("loads cached models from $XDG_CACHE_HOME/opencode when set", async () => {
     const fakeHome = path.join(os.tmpdir(), `cursor-plugin-test-${process.pid}-${Date.now()}`)
+    const xdgCache = path.join(fakeHome, "xdg-cache")
     process.env.HOME = fakeHome
-    delete process.env.XDG_CONFIG_HOME
+    process.env.XDG_CACHE_HOME = xdgCache
     const projectDir = path.join(fakeHome, "project")
-    const globalDir = path.join(fakeHome, ".config", "opencode")
+    const cacheDir = path.join(xdgCache, "opencode")
+    await mkdir(cacheDir, { recursive: true })
     await mkdir(projectDir, { recursive: true })
-    await writeCache(projectDir, {
+    await writeCache(cacheDir, {
       fetchedAt: Date.now(),
-      models: [{ id: "cursor-legacy-model", variants: [] }],
+      models: [{ id: "cursor-xdg-model", variants: [] }],
     })
 
     try {
@@ -167,8 +169,7 @@ describe("CursorPlugin config hook", () => {
       const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
       await plugin.config?.(config as never)
 
-      expect(config.provider?.cursor?.models).toHaveProperty("cursor-legacy-model")
-      expect((await readCache(globalDir))?.models[0]?.id).toBe("cursor-legacy-model")
+      expect(config.provider?.cursor?.models).toHaveProperty("cursor-xdg-model")
     } finally {
       await rm(fakeHome, { recursive: true, force: true })
     }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, afterEach } from "bun:test"
-import { mkdir, rm } from "node:fs/promises"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdir, writeFile, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { CursorPlugin, modelInfoToConfig, thinkingSuffixBaseNames } from "../src/plugin.js"
-import { writeCache, type ModelInfo } from "../src/models.js"
+import { readCache, writeCache, type ModelInfo } from "../src/models.js"
+import { resetClientVersionCache } from "../src/protocol/client-version.js"
 
 // Characters safeLabel must remove from emitted names/keys (issue #2).
 const INVALID = new RegExp("[()<>&\"'`]")
@@ -117,12 +118,18 @@ describe("modelInfoToConfig", () => {
 
 const originalHome = process.env.HOME
 const originalXdgCache = process.env.XDG_CACHE_HOME
+const originalXdgData = process.env.XDG_DATA_HOME
+const originalAuthContent = process.env.OPENCODE_AUTH_CONTENT
 
 afterEach(() => {
   if (originalHome === undefined) delete process.env.HOME
   else process.env.HOME = originalHome
   if (originalXdgCache === undefined) delete process.env.XDG_CACHE_HOME
   else process.env.XDG_CACHE_HOME = originalXdgCache
+  if (originalXdgData === undefined) delete process.env.XDG_DATA_HOME
+  else process.env.XDG_DATA_HOME = originalXdgData
+  if (originalAuthContent === undefined) delete process.env.OPENCODE_AUTH_CONTENT
+  else process.env.OPENCODE_AUTH_CONTENT = originalAuthContent
 })
 
 describe("CursorPlugin config hook", () => {
@@ -130,6 +137,7 @@ describe("CursorPlugin config hook", () => {
     const fakeHome = path.join(os.tmpdir(), `cursor-plugin-test-${process.pid}-${Date.now()}`)
     process.env.HOME = fakeHome
     delete process.env.XDG_CACHE_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
     const projectDir = path.join(fakeHome, "project")
     const cacheDir = path.join(fakeHome, ".cache", "opencode")
     await mkdir(cacheDir, { recursive: true })
@@ -155,6 +163,7 @@ describe("CursorPlugin config hook", () => {
     const xdgCache = path.join(fakeHome, "xdg-cache")
     process.env.HOME = fakeHome
     process.env.XDG_CACHE_HOME = xdgCache
+    delete process.env.OPENCODE_AUTH_CONTENT
     const projectDir = path.join(fakeHome, "project")
     const cacheDir = path.join(xdgCache, "opencode")
     await mkdir(cacheDir, { recursive: true })
@@ -173,5 +182,345 @@ describe("CursorPlugin config hook", () => {
     } finally {
       await rm(fakeHome, { recursive: true, force: true })
     }
+  })
+})
+
+function fakeJwt(expOffsetSec: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64")
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expOffsetSec }),
+  ).toString("base64")
+  return `${header}.${payload}.sig`
+}
+
+const INSTALLER_FIXTURE = `
+DOWNLOAD_URL="https://downloads.cursor.com/lab/2026.07.09-a3815c0/\${OS}/\${ARCH}/agent-cli-package.tar.gz"
+`
+
+describe("loadModels on cache miss", () => {
+  let fakeHome: string
+  let projectDir: string
+  let cacheDir: string
+  let dataDir: string
+  let realFetch: typeof globalThis.fetch
+  let availableModelsCalls: number
+  let refreshCalls: number
+  let persisted: unknown[]
+
+  async function writeAuth(cursor: unknown): Promise<void> {
+    await mkdir(dataDir, { recursive: true })
+    await writeFile(path.join(dataDir, "auth.json"), JSON.stringify({ cursor }))
+  }
+
+  function pluginInput() {
+    return {
+      directory: projectDir,
+      client: {
+        auth: {
+          set: async (opts: { body: unknown }) => {
+            persisted.push(opts.body)
+            return { data: true }
+          },
+        },
+      },
+    } as never
+  }
+
+  beforeEach(async () => {
+    fakeHome = path.join(os.tmpdir(), `cursor-miss-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_CACHE_HOME
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_AUTH_CONTENT
+    projectDir = path.join(fakeHome, "project")
+    cacheDir = path.join(fakeHome, ".cache", "opencode")
+    dataDir = path.join(fakeHome, ".local", "share", "opencode")
+    await mkdir(projectDir, { recursive: true })
+    availableModelsCalls = 0
+    refreshCalls = 0
+    persisted = []
+    realFetch = globalThis.fetch
+    resetClientVersionCache()
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/auth/token")) {
+        refreshCalls += 1
+        return Response.json({
+          accessToken: fakeJwt(3600),
+          refreshToken: "new-refresh",
+        })
+      }
+      if (url.includes("AvailableModels")) {
+        availableModelsCalls += 1
+        return Response.json({
+          models: [{ name: "fetched-model", clientDisplayName: "Fetched" }],
+        })
+      }
+      if (url.includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+  })
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch
+    resetClientVersionCache()
+    await rm(fakeHome, { recursive: true, force: true })
+  })
+
+  it("fetches and caches models when oauth auth exists and cache is empty", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(3600),
+      refresh: "refresh-tok",
+      expires: Date.now() + 3_600_000,
+    })
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toHaveProperty("fetched-model")
+    expect(availableModelsCalls).toBe(1)
+    expect(refreshCalls).toBe(0)
+    expect((await readCache(cacheDir))?.models[0]?.id).toBe("fetched-model")
+  })
+
+  it("refreshes expired oauth, preserves extras, then fetches models", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(-60),
+      refresh: "old-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-1",
+      enterpriseUrl: "https://enterprise.example",
+    })
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toHaveProperty("fetched-model")
+    expect(refreshCalls).toBe(1)
+    expect(availableModelsCalls).toBe(1)
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0]).toMatchObject({
+      type: "oauth",
+      refresh: "new-refresh",
+      accountId: "acct-1",
+      enterpriseUrl: "https://enterprise.example",
+    })
+  })
+
+  it("returns empty models when auth.json is absent", async () => {
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toEqual({})
+    expect(availableModelsCalls).toBe(0)
+  })
+
+  it("returns empty models when oauth refresh is missing and token is expired", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(-60),
+      refresh: "",
+      expires: Date.now() - 60_000,
+    })
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toEqual({})
+    expect(availableModelsCalls).toBe(0)
+    expect(refreshCalls).toBe(0)
+    expect(persisted).toHaveLength(0)
+  })
+
+  it("returns empty models when refresh fails and does not persist half-state", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(-60),
+      refresh: "bad-refresh",
+      expires: Date.now() - 60_000,
+      enterpriseUrl: "https://enterprise.example",
+    })
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/auth/token")) {
+        refreshCalls += 1
+        return new Response("nope", { status: 500 })
+      }
+      if (url.includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toEqual({})
+    expect(refreshCalls).toBe(1)
+    expect(availableModelsCalls).toBe(0)
+    expect(persisted).toHaveLength(0)
+  })
+
+  it("still uses refreshed oauth token when persistAuth fails", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(-60),
+      refresh: "old-refresh",
+      expires: Date.now() - 60_000,
+    })
+
+    const plugin = await CursorPlugin({
+      directory: projectDir,
+      client: {
+        auth: {
+          set: async () => {
+            throw new Error("auth.set failed")
+          },
+        },
+      },
+    } as never)
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toHaveProperty("fetched-model")
+    expect(refreshCalls).toBe(1)
+    expect(availableModelsCalls).toBe(1)
+  })
+
+  it("fetches and caches models when api auth exists and cache is empty", async () => {
+    await writeAuth({
+      type: "api",
+      key: fakeJwt(3600),
+      metadata: { refreshToken: "api-refresh" },
+    })
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toHaveProperty("fetched-model")
+    expect(availableModelsCalls).toBe(1)
+    expect(refreshCalls).toBe(0)
+    expect((await readCache(cacheDir))?.models[0]?.id).toBe("fetched-model")
+  })
+
+  it("refreshes expired api key via metadata.refreshToken, then fetches models", async () => {
+    await writeAuth({
+      type: "api",
+      key: fakeJwt(-60),
+      metadata: { refreshToken: "api-refresh", note: "keep-me" },
+    })
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+
+    expect(config.provider?.cursor?.models).toHaveProperty("fetched-model")
+    expect(refreshCalls).toBe(1)
+    expect(availableModelsCalls).toBe(1)
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0]).toMatchObject({
+      type: "api",
+      metadata: { refreshToken: "new-refresh", note: "keep-me" },
+    })
+  })
+
+  it("loader skips discoverModels when config already wrote a fresh cache", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(3600),
+      refresh: "refresh-tok",
+      expires: Date.now() + 3_600_000,
+    })
+
+    const plugin = await CursorPlugin(pluginInput())
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+    expect(availableModelsCalls).toBe(1)
+
+    const auth = plugin.auth
+    if (!auth || !("loader" in auth) || !auth.loader) throw new Error("missing loader")
+    await auth.loader(async () => ({
+      type: "oauth",
+      access: fakeJwt(3600),
+      refresh: "refresh-tok",
+      expires: Date.now() + 3_600_000,
+    }), {} as never)
+
+    // Fresh cache from config — no second AvailableModels (and no background kick).
+    expect(availableModelsCalls).toBe(1)
+  })
+
+  it("loader falls back to session token when getAuth refresh fails after config already refreshed", async () => {
+    await writeAuth({
+      type: "oauth",
+      access: fakeJwt(-60),
+      refresh: "one-shot-refresh",
+      expires: Date.now() - 60_000,
+    })
+
+    let refreshPhase = 0
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/auth/token")) {
+        refreshCalls += 1
+        refreshPhase += 1
+        if (refreshPhase === 1) {
+          return Response.json({
+            accessToken: fakeJwt(3600),
+            refreshToken: "new-refresh",
+          })
+        }
+        return new Response("reuse denied", { status: 401 })
+      }
+      if (url.includes("AvailableModels")) {
+        availableModelsCalls += 1
+        return Response.json({
+          models: [{ name: "fetched-model", clientDisplayName: "Fetched" }],
+        })
+      }
+      if (url.includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    const plugin = await CursorPlugin({
+      directory: projectDir,
+      client: {
+        auth: {
+          set: async () => {
+            throw new Error("auth.set failed")
+          },
+        },
+      },
+    } as never)
+    const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+    await plugin.config?.(config as never)
+    expect(config.provider?.cursor?.models).toHaveProperty("fetched-model")
+
+    const auth = plugin.auth
+    if (!auth || !("loader" in auth) || !auth.loader) throw new Error("missing loader")
+    // getAuth still returns pre-refresh credentials; second refresh fails.
+    const opts = await auth.loader(async () => ({
+      type: "oauth",
+      access: fakeJwt(-60),
+      refresh: "one-shot-refresh",
+      expires: Date.now() - 60_000,
+    }), {} as never)
+
+    expect(opts.accessToken).toBeDefined()
+    expect(availableModelsCalls).toBe(1)
   })
 })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from "bun:test"
-import { modelInfoToConfig, thinkingSuffixBaseNames } from "../src/plugin.js"
-import type { ModelInfo } from "../src/models.js"
+import { describe, it, expect, afterEach } from "bun:test"
+import { mkdir, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { CursorPlugin, modelInfoToConfig, thinkingSuffixBaseNames } from "../src/plugin.js"
+import { readCache, writeCache, type ModelInfo } from "../src/models.js"
 
 // Characters safeLabel must remove from emitted names/keys (issue #2).
 const INVALID = new RegExp("[()<>&\"'`]")
@@ -108,6 +111,66 @@ describe("modelInfoToConfig", () => {
     expect(thinkingSuffixBaseNames(models)).toEqual(new Set())
     for (const m of models) {
       expect(modelInfoToConfig(m, { thinkingSuffix: false }).name).toBe(m.displayName)
+    }
+  })
+})
+
+const originalHome = process.env.HOME
+const originalXdg = process.env.XDG_CONFIG_HOME
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME
+  else process.env.XDG_CONFIG_HOME = originalXdg
+})
+
+describe("CursorPlugin config hook", () => {
+  it("loads cached models from the global OpenCode config dir, not input.directory", async () => {
+    const fakeHome = path.join(os.tmpdir(), `cursor-plugin-test-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_CONFIG_HOME
+    const projectDir = path.join(fakeHome, "project")
+    const globalDir = path.join(fakeHome, ".config", "opencode")
+    await mkdir(globalDir, { recursive: true })
+    await mkdir(projectDir, { recursive: true })
+    await writeCache(globalDir, {
+      fetchedAt: Date.now(),
+      models: [{ id: "cursor-test-model", variants: [] }],
+    })
+
+    try {
+      const plugin = await CursorPlugin({ directory: projectDir } as never)
+      const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+      await plugin.config?.(config as never)
+
+      expect(config.provider?.cursor?.models).toHaveProperty("cursor-test-model")
+    } finally {
+      await rm(fakeHome, { recursive: true, force: true })
+    }
+  })
+
+  it("migrates a project-scoped model cache into the global config dir", async () => {
+    const fakeHome = path.join(os.tmpdir(), `cursor-plugin-test-${process.pid}-${Date.now()}`)
+    process.env.HOME = fakeHome
+    delete process.env.XDG_CONFIG_HOME
+    const projectDir = path.join(fakeHome, "project")
+    const globalDir = path.join(fakeHome, ".config", "opencode")
+    await mkdir(projectDir, { recursive: true })
+    await writeCache(projectDir, {
+      fetchedAt: Date.now(),
+      models: [{ id: "cursor-legacy-model", variants: [] }],
+    })
+
+    try {
+      const plugin = await CursorPlugin({ directory: projectDir } as never)
+      const config: { provider?: Record<string, { models?: Record<string, unknown> }> } = {}
+      await plugin.config?.(config as never)
+
+      expect(config.provider?.cursor?.models).toHaveProperty("cursor-legacy-model")
+      expect((await readCache(globalDir))?.models[0]?.id).toBe("cursor-legacy-model")
+    } finally {
+      await rm(fakeHome, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
Fixes #4

## Summary

- Store `cursor-models.json` (and client-version cache) under OpenCode’s **cache** dir: `$XDG_CACHE_HOME/opencode` when set, else `~/.cache/opencode` — not the project cwd and not `~/.config`.
- Drop `CURSOR_CONFIG_DIR` for model cache paths.
- When the cache is empty/missing but Cursor credentials remain in OpenCode `auth.json`, **fetch models during config load** so a deleted cache + restart repopulates the picker.
- Auth loader awaits discovery when the cache is stale/empty, skips a second fetch when config already wrote a fresh cache, and falls back to an in-memory session token if refresh was already done in-process.
- Token refresh persists best-effort (failed `auth.set` no longer discards a valid new token); OAuth optional fields (`accountId`, `enterpriseUrl`) are preserved.

## Test plan

- [ ] Delete `~/.cache/opencode/cursor-models.json`, restart OpenCode with Cursor still logged in → models reappear and the file is rewritten
- [ ] `opencode models` lists cursor models after auth
- [ ] With `XDG_CACHE_HOME` set, cache lands under `$XDG_CACHE_HOME/opencode/`
- [ ] `bun test` / `bun run typecheck` pass