### PR TITLE
fix: strip OpenCode read envelope before Cursor sees it

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenCode driving a Cursor-routed Grok model through this provider:
 - **Authentication** — browser OAuth (PKCE), or API key from [cursor.com/settings](https://cursor.com/settings)
 - **Model discovery** — fetches available models from Cursor's API and caches them locally
 - **Streaming** — bidirectional Connect-RPC stream for agent runs
-- **Tool calls** — maps Cursor exec-server messages to AI SDK tool-call parts
+- **Tool calls** — maps Cursor exec-server messages to AI SDK tool-call parts; strips OpenCode's `read` XML envelope (`<path>`/`<content>` + `N:` prefixes) before returning content to Cursor so the model cannot echo the wrapper into writes
 - **Thinking / reasoning** — surfaces extended-thinking deltas where the model supports it
 
 ## Requirements
@@ -181,6 +181,7 @@ OpenCode
 | `src/index.ts` | `createCursor` factory; default export is `CursorPlugin` |
 | `src/language-model.ts` | AI SDK `LanguageModelV3` adapter (`doStream`, `doGenerate`) |
 | `src/session.ts` | Held-open agent Run session and pending exec correlation |
+| `src/debug.ts` | Opt-in wire-level debug logging (`CURSOR_PROVIDER_DEBUG`) |
 | `src/auth.ts` | PKCE OAuth, API key exchange, JWT refresh |
 | `src/models.ts` | `AvailableModels` fetch and `cursor-models.json` cache |
 | `src/agent-url.ts` | `GetServerConfig` fetch + in-process memo (region-specific Run host) |

--- a/bun.lock
+++ b/bun.lock
@@ -34,9 +34,9 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.17.13", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-JjoIs6qTPl0IrXo+J1GTqX9lcb2h2dMoW6BWMR2IbTT3MY2FQ/lvBXDzkx0d3zVRaYN+NTmV4u8Nth396xq+sQ=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.18.2", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.18.2", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.3", "@opentui/keymap": ">=0.4.3", "@opentui/solid": ">=0.4.3" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-h0N1mShfSfaI0pMHXCAdEevF5fVZ+u+F8B4/PDEurpFIk7n/mSjYkgjVvekIR3Z4SJkApkVlwekctIPO7JhLvg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-VItOGjMzRQx3zypwmeFLNhCiIx32kxS7FqzIJvVZLfyNGCifs3rfGC9qzNKWcxQo4SjNvAw++v4gWWU6Inv+JQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.2", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-40DIMMrl2W0TMFKtTnrYKed3ElXhqEkP0oLahQEd6Mm9mTdu/B2Bc9A19++IkKKFIxbxKFaUhik+vBUiNBrFtA=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "protobufjs": "^7.4.0"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": "~1.17.13"
+    "@opencode-ai/plugin": "^1.17.13"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "~1.17.13",
+    "@opencode-ai/plugin": "^1.17.13",
     "@tsconfig/node22": "^22.0.1",
     "@types/node": "^22.15.3",
     "typescript": "^5.8.3"

--- a/src/agent-url.ts
+++ b/src/agent-url.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto"
-import { fetchAgentUrl, trace } from "./transport/connect.js"
+import { fetchAgentUrl } from "./transport/connect.js"
+import { trace } from "./debug.js"
 import { CURSOR_API_HOST } from "./shared.js"
 
 const DEFAULT_API_BASE = `https://${CURSOR_API_HOST}`

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs"
+
+// Wire-level diagnostics. Opt in with CURSOR_PROVIDER_DEBUG=1 (or "true").
+// Writes to CURSOR_PROVIDER_DEBUG_FILE (default /tmp/cursor-provider-debug.log).
+// Truncated once per process. Tokens / checksums should be redacted by callers.
+const DEBUG_ENABLED =
+  process.env.CURSOR_PROVIDER_DEBUG === "1" ||
+  process.env.CURSOR_PROVIDER_DEBUG === "true"
+const DEBUG_FILE = process.env.CURSOR_PROVIDER_DEBUG_FILE || "/tmp/cursor-provider-debug.log"
+let _traceInitialized = false
+
+export function trace(msg: string): void {
+  if (!DEBUG_ENABLED) return
+  try {
+    if (!_traceInitialized) {
+      _traceInitialized = true
+      fs.writeFileSync(
+        DEBUG_FILE,
+        `--- cursor-provider debug (pid ${process.pid}) ${new Date().toISOString()} ---\n`,
+      )
+    }
+    fs.appendFileSync(DEBUG_FILE, `[${new Date().toISOString()}] ${msg}\n`)
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -2,7 +2,8 @@ import fs from "node:fs"
 import { createHash } from "node:crypto"
 import type { LanguageModelV3, LanguageModelV3CallOptions, LanguageModelV3StreamResult, LanguageModelV3GenerateResult, LanguageModelV3StreamPart, LanguageModelV3Usage, LanguageModelV3FinishReason } from "@ai-sdk/provider"
 import type { CreateCursorOptions } from "./index.js"
-import { bidiRunStream, normalizeAgentRunOrigin, trace } from "./transport/connect.js"
+import { bidiRunStream, normalizeAgentRunOrigin } from "./transport/connect.js"
+import { trace } from "./debug.js"
 import { buildRunRequest, buildHeartbeat } from "./protocol/request.js"
 import { decodeFramePayload } from "./protocol/framing.js"
 import { decodeMessage } from "./protocol/messages.js"
@@ -111,6 +112,7 @@ async function doStreamImpl(
           resultField: pending.resultField,
           output: r.output,
           error: r.error,
+          toolName: pending.toolName ?? r.toolName,
         })) {
           session.stream.write(frame)
         }
@@ -633,6 +635,7 @@ async function pump(
                 resultField: parsed.resultField,
                 output: "",
                 error: reason,
+                toolName: parsed.toolName,
               })) {
                 session.stream.write(frame)
               }
@@ -643,7 +646,7 @@ async function pump(
           }
           const tc = buildToolCallPart(parsed, session.sessionId)
           // Keep the stream open; the result arrives on the next doStream call.
-          sessionManager.registerPending(parsed.id, session, parsed.resultField)
+          sessionManager.registerPending(parsed.id, session, parsed.resultField, parsed.toolName)
           // tc.input is already a JSON string (LanguageModelV3ToolCall.input).
           trace(`exec: EMITTED tool-call toolCallId=${tc.toolCallId} toolName=${tc.toolName} inputLen=${tc.input.length}`)
           // Close open text/reasoning spans before tool-call (required by AI SDK V3).

--- a/src/protocol/tools.ts
+++ b/src/protocol/tools.ts
@@ -1,5 +1,6 @@
 import { encodeMessage } from "./messages.js"
 import { encodeJsonAsValue, decodeStructEntriesToJson, readAllFields } from "./struct.js"
+import { trace } from "../debug.js"
 
 // Exec variant field number whose reply is the server-initiated request_context
 // probe (ExecServerMessage #10 → ExecClientMessage #10). request/result share a
@@ -414,6 +415,12 @@ export type ToolResultInput = {
   output: string
   error?: string
   executionTimeMs?: number
+  /**
+   * Resolved opencode tool name (read/write/grep/…). Gates read-envelope
+   * unwrapping on the mcp_result path so non-read MCP output is never
+   * rewritten. read_result is always a read, so it unwraps regardless.
+   */
+  toolName?: string
 }
 
 /**
@@ -446,7 +453,7 @@ export function buildExecClientMessages(input: ToolResultInput): Uint8Array[] {
       id: input.execId,
       local_execution_time_ms: input.executionTimeMs ?? 0,
     }
-    clientMsg[resultField] = buildTypedExecResult(resultField, input.output, input.error)
+    clientMsg[resultField] = buildTypedExecResult(resultField, input.output, input.error, input.toolName)
     frames.push(
       encodeMessage("AgentClientMessage", {
         exec_client_message: clientMsg,
@@ -469,6 +476,69 @@ export function buildExecStreamClose(execId: number): Uint8Array {
 }
 
 /**
+ * Strip opencode's `read` envelope, leaving raw file content.
+ *
+ * opencode's read tool (opencode `tool/read.ts`) wraps content in an XML-ish
+ * envelope its own models are trained on, but Cursor's are not:
+ *   <path>{abs}</path>\n<type>file</type>\n<content>\n{N}: {line}\n…\n\n{footer}\n</content>
+ * Forwarding that envelope verbatim made Cursor's model treat the wrapper as
+ * literal file content and write `<path>`/`<content>` tags + `N:` line prefixes
+ * back into files (silent corruption — the write still reports success; seen
+ * across 8+ sessions, e.g. language-model.ts rewritten starting with
+ * `<path>…</path>\n<type>file</type>\n<content>\n1: import fs…`).
+ *
+ * Returns the raw file body (line numbers + footer + `<system-reminder>` dropped).
+ *
+ * Deliberately exception-safe: if the expected envelope is absent — non-read
+ * output, already-raw text, or a future opencode format change — it returns the
+ * input unchanged, so a result is never broken and we never throw mid-turn.
+ * Callers must still gate `mcp_result` on `toolName === "read"`; this helper
+ * alone is not a tool-identity check.
+ */
+export function unwrapReadOutput(output: string): string {
+  if (typeof output !== "string" || output.length === 0) return output
+  // Require the full opencode read-envelope skeleton *before* `<content>`
+  // (read.ts opens with <path>…</path>, <type>file</type>, <content>) so a
+  // stray "<content>" later in tool chatter can't trigger unwrapping just
+  // because path/type tags appear elsewhere in the payload.
+  const contentHeaderIdx = output.indexOf("<content>")
+  if (contentHeaderIdx === -1) return output
+  const header = output.slice(0, contentHeaderIdx)
+  const hasSkeleton =
+    header.indexOf("<path>") !== -1 &&
+    header.indexOf("<type>file</type>") !== -1
+  if (!hasSkeleton) {
+    // Saw "<content>" but not the read skeleton ahead of it — almost certainly
+    // a non-read payload, or an opencode format drift. Surface it so drift
+    // can't silently resurrect the wrapper-corruption bug, but still fail
+    // safe (no mutate).
+    trace("unwrapReadOutput: <content> present without leading <path>/<type>file> skeleton — leaving output unchanged (possible non-read payload or opencode read format drift)")
+    return output
+  }
+  // Body starts right after "<content>\n". opencode emits one numbered line per
+  // file line ("N: <line>"), then a blank, a "(…)" footer, and a standalone
+  // "</content>". The body is a *contiguous run* of /^N: / lines — so we stop at
+  // the first non-numbered line. Critically we do NOT search for a closing
+  // "</content>" substring: a file line that literally contains "</content>"
+  // is rendered as "N: </content>" (a body line), and a raw indexOf would
+  // truncate the read there.
+  let rest = output.slice(contentHeaderIdx + "<content>".length)
+  if (rest.startsWith("\n")) rest = rest.slice(1)
+  const raw: string[] = []
+  for (const line of rest.split("\n")) {
+    const m = /^(\d+):[ \t]?(.*)$/.exec(line)
+    if (!m) break // blank / "(footer)" / "</content>" → end of body run
+    // Strip only the leading "N: " prefix; a line that itself begins with
+    // digits+colon keeps its content (we remove just the first match). Blank
+    // file lines render as "N: " and are preserved (capture group is "").
+    raw.push(m[2])
+  }
+  // Envelope confirmed but no numbered body → empty file. Return "" rather
+  // than the envelope (the envelope is exactly what Cursor echoes into writes).
+  return raw.join("\n")
+}
+
+/**
  * Map OpenCode tool text into the agent.v1 result oneof for each exec variant.
  * OpenCode returns free-form text; we wrap it in the minimal success shape the
  * server accepts (verified against agent.v1 wire captures).
@@ -477,15 +547,20 @@ export function buildTypedExecResult(
   resultField: string,
   output: string,
   error?: string,
+  toolName?: string,
 ): Record<string, unknown> {
   switch (resultField) {
     case "read_result":
       if (error) return { error: { path: "", error } }
+      // Strip opencode's <path>/<content> envelope so Cursor's model receives
+      // raw file content and can't echo the wrapper into subsequent writes.
+      // reads route here only for native read_args; most arrive via mcp_result.
+      const content = unwrapReadOutput(output)
       return {
         success: {
           path: extractPathTag(output) ?? "",
-          content: output,
-          total_lines: countLines(output),
+          content,
+          total_lines: countLines(content),
         },
       }
     case "grep_result": {
@@ -546,9 +621,15 @@ export function buildTypedExecResult(
     }
     case "mcp_result":
       if (error) return { error: { error } }
+      // opencode built-ins (read/write/grep/…) are advertised as MCP tools, so
+      // a read call returns through mcp_result. Scope the unwrap to toolName
+      // "read" so a non-read MCP tool whose output merely contains a
+      // "<content>"-like block is never rewritten.
       return {
         success: {
-          content: [{ text: { text: output } }],
+          content: [
+            { text: { text: toolName === "read" ? unwrapReadOutput(output) : output } },
+          ],
           is_error: false,
         },
       }
@@ -698,4 +779,3 @@ export function buildRequestContextResult(
     },
   })
 }
-

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,5 @@
 import type { BidiStream } from "./transport/connect.js"
-import { trace } from "./transport/connect.js"
+import { trace } from "./debug.js"
 
 export type Frame = { flags: number; payload: Uint8Array }
 
@@ -14,6 +14,11 @@ export type Frame = { flags: number; payload: Uint8Array }
 export type PendingExec = {
   /** ExecClientMessage result field to reply with (matches the request variant). */
   resultField: string
+  /**
+   * Resolved opencode tool name (read/write/grep/…). Used on continuation so
+   * mcp_result can unwrap read envelopes even if the prompt omits toolName.
+   */
+  toolName?: string
 }
 
 export type CursorSession = {
@@ -70,8 +75,13 @@ export class SessionManager {
   }
 
   /** Register that `session` is awaiting a result for `execId`. */
-  registerPending(execId: number, session: CursorSession, resultField: string): void {
-    session.pending.set(execId, { resultField })
+  registerPending(
+    execId: number,
+    session: CursorSession,
+    resultField: string,
+    toolName?: string,
+  ): void {
+    session.pending.set(execId, { resultField, toolName })
     this.byExecId.set(this.key(session.sessionId, execId), session)
     this.touch(session)
   }

--- a/src/transport/connect.ts
+++ b/src/transport/connect.ts
@@ -3,36 +3,15 @@ import { encodeFrame, streamFrames } from "../protocol/framing.js"
 import { createCursorChecksumHeader } from "../protocol/checksum.js"
 import { getDeviceIds } from "../protocol/device-id.js"
 import { resolveClientVersion } from "../protocol/client-version.js"
+import { trace } from "../debug.js"
 import http2 from "node:http2"
-import fs from "node:fs"
 
 const API_BASE = `https://${CURSOR_API_HOST}`
 
 function resolveApiBaseURL(options: { apiBaseURL?: string; baseURL?: string }): string {
   return new URL(options.apiBaseURL ?? options.baseURL ?? API_BASE).origin
 }
-// Wire-level diagnostics. Opt in with CURSOR_PROVIDER_DEBUG=1 (or "true").
-// Writes to CURSOR_PROVIDER_DEBUG_FILE (default /tmp/cursor-provider-debug.log).
-// Truncated once per process. Captures h2 response status, parsed frames, and
-// stream errors. Tokens / checksums are redacted in header dumps.
-const DEBUG_ENABLED =
-  process.env.CURSOR_PROVIDER_DEBUG === "1" ||
-  process.env.CURSOR_PROVIDER_DEBUG === "true"
-const DEBUG_FILE = process.env.CURSOR_PROVIDER_DEBUG_FILE || "/tmp/cursor-provider-debug.log"
-let _traceInitialized = false
-export function trace(msg: string): void {
-  if (!DEBUG_ENABLED) return
-  try {
-    if (!_traceInitialized) {
-      _traceInitialized = true
-      fs.writeFileSync(
-        DEBUG_FILE,
-        `--- cursor-provider debug (pid ${process.pid}) ${new Date().toISOString()} ---\n`,
-      )
-    }
-    fs.appendFileSync(DEBUG_FILE, `[${new Date().toISOString()}] ${msg}\n`)
-  } catch { /* ignore */ }
-}
+
 trace("connect.ts module loaded")
 
 export function buildBaseHeaders(

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -29,6 +29,16 @@ describe("SessionManager", () => {
     expect(mgr.findByExecIds(s.sessionId, [99])).toBeUndefined()
   })
 
+  it("stores optional toolName on pending for continuation unwrap gating", () => {
+    const mgr = new SessionManager()
+    const s = fakeSession()
+    mgr.registerPending(3, s, "mcp_result", "read")
+    expect(mgr.pendingFor(s.sessionId, 3)).toEqual({
+      resultField: "mcp_result",
+      toolName: "read",
+    })
+  })
+
   it("resolves an exec id so it is no longer found", () => {
     const mgr = new SessionManager()
     const s = fakeSession()

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -11,6 +11,8 @@ import {
   detectExecVariantField,
   buildRawEmptyExecReply,
   buildRequestContextResult,
+  buildTypedExecResult,
+  unwrapReadOutput,
   REQUEST_CONTEXT_RESULT_FIELD,
 } from "../src/protocol/tools.js"
 import { decodeMessage, encodeMessage } from "../src/protocol/messages.js"
@@ -447,6 +449,188 @@ describe("mapCursorArgsToOpencode read zeros", () => {
       limit: 0,
     })
     expect(r).toEqual({ toolName: "read", args: { filePath: "/README.md" } })
+  })
+})
+
+// Real opencode read output (tool/read.ts): an XML envelope + `N: ` line
+// prefixes + a footer, which Cursor's model is not trained on and echoes into
+// writes. buildTypedExecResult must strip it down to raw file content.
+const OPENCODE_READ_FULL = [
+  "<path>/abs/file.ts</path>",
+  "<type>file</type>",
+  "<content>",
+  "1: import fs from \"node:fs\"",
+  "2: ",
+  "3: const x = 1",
+  "",
+  "(End of file - total 3 lines)",
+  "</content>",
+].join("\n")
+
+const OPENCODE_READ_PAGED = [
+  "<path>/abs/big.ts</path>",
+  "<type>file</type>",
+  "<content>",
+  "100: lineA",
+  "101: lineB",
+  "",
+  "(Showing lines 100-101 of 500. Use offset=102 to continue.)",
+  "</content>",
+  "",
+  "<system-reminder>",
+  "loaded instruction text",
+  "</system-reminder>",
+].join("\n")
+
+describe("unwrapReadOutput", () => {
+  it("strips the envelope, line numbers, footer → raw file content", () => {
+    expect(unwrapReadOutput(OPENCODE_READ_FULL)).toBe(
+      "import fs from \"node:fs\"\n\nconst x = 1",
+    )
+  })
+
+  it("preserves blank file lines (rendered as `N: `)", () => {
+    expect(unwrapReadOutput(OPENCODE_READ_FULL)).toContain("\n\nconst x = 1")
+  })
+
+  it("handles offset/pagination footer + trailing <system-reminder>", () => {
+    // system-reminder sits after </content> and must be excluded entirely.
+    expect(unwrapReadOutput(OPENCODE_READ_PAGED)).toBe("lineA\nlineB")
+  })
+
+  it("strips only the first N: prefix on a line that itself contains digits+colon", () => {
+    const out = [
+      "<path>/x</path>", "<type>file</type>", "<content>",
+      "1: 42: the answer",
+      "", "(End of file - total 1 lines)", "</content>",
+    ].join("\n")
+    expect(unwrapReadOutput(out)).toBe("42: the answer")
+  })
+
+  it("does NOT truncate when a file line contains the literal </content> (Finding 1)", () => {
+    // opencode renders such a line as "N: </content>". A naive indexOf("</content>")
+    // would close early and drop the rest of the file. The structural parser
+    // treats it as a body line.
+    const out = [
+      "<path>/x</path>", "<type>file</type>", "<content>",
+      "1: before",
+      "2: </content>",
+      "3: after",
+      "", "(End of file - total 3 lines)", "</content>",
+    ].join("\n")
+    expect(unwrapReadOutput(out)).toBe("before\n</content>\nafter")
+  })
+
+  it("does NOT truncate when a file line contains the literal <content>", () => {
+    const out = [
+      "<path>/x</path>", "<type>file</type>", "<content>",
+      "1: a",
+      "2: <content>",
+      "3: b",
+      "", "(End of file - total 3 lines)", "</content>",
+    ].join("\n")
+    expect(unwrapReadOutput(out)).toBe("a\n<content>\nb")
+  })
+
+  it("returns \"\" for an empty-file envelope (Finding 3), not the envelope", () => {
+    const empty = [
+      "<path>/x</path>", "<type>file</type>", "<content>",
+      "", "(End of file - total 0 lines)", "</content>",
+    ].join("\n")
+    expect(unwrapReadOutput(empty)).toBe("")
+  })
+
+  it("is a no-op when <content> lacks the read skeleton (non-read / drift, Finding 4)", () => {
+    // A non-read MCP payload that happens to mention "<content>" must not be rewritten.
+    const trick = "here is a doc\n<content>\n1: fake\n</content>\nmore doc"
+    expect(unwrapReadOutput(trick)).toBe(trick)
+  })
+
+  it("is a no-op when skeleton tags appear only after <content>", () => {
+    // Path/type after the content header must not count — ordered check.
+    const trick = [
+      "<content>",
+      "1: fake",
+      "</content>",
+      "<path>/x</path>",
+      "<type>file</type>",
+    ].join("\n")
+    expect(unwrapReadOutput(trick)).toBe(trick)
+  })
+
+  it("is a no-op for non-envelope output (e.g. grep/bash text)", () => {
+    const grep = "Found 2 matches\n/a.ts:\n  Line 3: foo"
+    expect(unwrapReadOutput(grep)).toBe(grep)
+  })
+
+  it("is a no-op for already-raw / plain content", () => {
+    expect(unwrapReadOutput("just plain text\nno envelope")).toBe("just plain text\nno envelope")
+  })
+
+  it("never throws on non-string / empty input", () => {
+    expect(unwrapReadOutput("" as string)).toBe("")
+    expect(unwrapReadOutput(undefined as unknown as string)).toBe(undefined)
+  })
+})
+
+describe("buildTypedExecResult read-envelope unwrap", () => {
+  it("read_result.content is raw content (no <path>/<content>/N: prefixes)", () => {
+    const r = buildTypedExecResult("read_result", OPENCODE_READ_FULL) as {
+      success: { path: string; content: string; total_lines: number }
+    }
+    expect(r.success.path).toBe("/abs/file.ts") // path still parsed from <path>
+    expect(r.success.content).toBe("import fs from \"node:fs\"\n\nconst x = 1")
+    expect(r.success.content).not.toContain("<path>")
+    expect(r.success.content).not.toContain("<content>")
+    expect(r.success.content).not.toMatch(/^\d+: /m)
+    expect(r.success.total_lines).toBe(3)
+  })
+
+  it("read_result empty file → content \"\" (no envelope echoed)", () => {
+    const empty = [
+      "<path>/x</path>", "<type>file</type>", "<content>",
+      "", "(End of file - total 0 lines)", "</content>",
+    ].join("\n")
+    const r = buildTypedExecResult("read_result", empty) as {
+      success: { content: string }
+    }
+    expect(r.success.content).toBe("")
+  })
+
+  it("mcp_result text is unwrapped for read-via-MCP when toolName=read", () => {
+    const r = buildTypedExecResult("mcp_result", OPENCODE_READ_PAGED, undefined, "read") as {
+      success: { content: Array<{ text: { text: string } }> }
+    }
+    expect(r.success.content[0].text.text).toBe("lineA\nlineB")
+  })
+
+  it("mcp_result text is left untouched for a non-read tool even if it looks enveloped (Finding 2)", () => {
+    // A grep/context7 result that happens to embed an opencode-shaped block
+    // must survive verbatim because toolName != read.
+    const r = buildTypedExecResult("mcp_result", OPENCODE_READ_FULL, undefined, "brave_web_search") as {
+      success: { content: Array<{ text: { text: string } }> }
+    }
+    expect(r.success.content[0].text.text).toBe(OPENCODE_READ_FULL)
+  })
+
+  it("mcp_result text is a no-op for plain non-read MCP output", () => {
+    const r = buildTypedExecResult("mcp_result", "{\"ok\":true}") as {
+      success: { content: Array<{ text: { text: string } }> }
+    }
+    expect(r.success.content[0].text.text).toBe("{\"ok\":true}")
+  })
+
+  it("end-to-end: read-via-MCP envelope → exec_client_message carries raw content", () => {
+    const frames = buildExecClientMessages({
+      execId: 1,
+      resultField: "mcp_result",
+      output: OPENCODE_READ_FULL,
+      toolName: "read",
+    })
+    const ec = decodeMessage<any>("AgentClientMessage", frames[0]).exec_client_message
+    expect(ec.mcp_result.success.content[0].text.text).toBe(
+      "import fs from \"node:fs\"\n\nconst x = 1",
+    )
   })
 })
 


### PR DESCRIPTION
## What Problem This Solves
OpenCode's `read` tool wraps file content in an XML-ish envelope (`<path>`, `<type>file</type>`, `<content>`, numbered `N:` lines, footer). Cursor models are not trained on that wrapper. When this provider forwarded the envelope verbatim, Cursor treated it as literal file content and wrote the tags and line prefixes back into files — silent corruption (writes still reported success).

## Why This Change Was Made
- Add `unwrapReadOutput()` to strip the envelope structurally (contiguous `N:` body run; no `</content>` substring search, so literal tags inside file lines are preserved).
- Apply unwrap on native `read_result` always; on `mcp_result` only when `toolName === "read"` (OpenCode builtins arrive as MCP).
- Thread `toolName` through tool-result replies and store it on pending execs so continuation unwrap gating does not depend solely on the prompt echoing the name.
- Move `trace()` to `src/debug.ts` so protocol code does not import transport for logging.
- Document the behavior in README; add regression tests for empty files, embedded tags, non-read MCP payloads, and ordered skeleton checks.
- Widen `@opencode-ai/plugin` peer/dev range from `~1.17.13` to `^1.17.13` and lock to resolved `1.18.2` (with matching sdk) for current OpenCode plugin compatibility.

## User Impact
- Cursor-routed models receive raw file content from OpenCode `read`, not the wrapper.
- Stops a class of silent file rewrites that previously corrupted source across multi-turn sessions.
- Non-read MCP / tool output is left unchanged.
- No auth, model list, or streaming behavior changes for end users.
- Dev/peer installs can resolve newer OpenCode plugin 1.18.x.

## Evidence
- Unit coverage in `test/tools.test.ts` (`unwrapReadOutput`, `buildTypedExecResult` mcp/read paths) and `test/session.test.ts` (pending `toolName`).
- `bun test`: 285 pass, 0 fail.
- `bun run typecheck`: clean.
- `package.json` / `bun.lock`: `@opencode-ai/plugin` `^1.17.13` → lockfile `1.18.2`.
