### PR TITLE
fix: validate model caches and variant selections (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ opencode run --model cursor/composer-2.5 "Hello from Cursor via OpenCode"
 
 Cursor models often expose parameterized variants (effort, thinking, fast, context tier, …). The plugin materializes those as OpenCode **model variants**. In the TUI, pick one from the variant dialog or cycle with OpenCode’s `variant_cycle` keybind (default `ctrl+t`).
 
-The selected variant’s Cursor parameter map is forwarded on the Run as `requested_model.parameters` (isolated under `providerOptions.cursor.cursorVariantParameters` so unrelated OpenCode options are not leaked onto the wire).
+The selected variant’s Cursor parameter map is forwarded on the Run as `requested_model.parameters` (isolated under `providerOptions.cursor.cursorVariantParameters` so unrelated OpenCode options are not leaked onto the wire). The provider validates that explicit selection against the current cached tuple; malformed, reordered, or stale selections fail clearly instead of silently falling back to another variant.
 
 #### 1M / long context
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,8 +1,7 @@
 import { MODEL_CACHE_FILE, MODEL_CACHE_SCHEMA_VERSION, MODEL_CACHE_TTL_MS } from "./shared.js"
 import { unaryAvailableModels } from "./transport/connect.js"
 import { buildRequestedModelParams } from "./protocol/thinking.js"
-import { readFile, writeFile, mkdir } from "node:fs/promises"
-import { existsSync } from "node:fs"
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises"
 import path from "node:path"
 
 // ── Types ──
@@ -42,6 +41,176 @@ export type ModelCache = {
   schemaVersion?: number
 }
 
+export class CursorVariantSelectionError extends Error {
+  constructor(message: string) {
+    super(`Cursor variant selection ${message}`)
+    this.name = "CursorVariantSelectionError"
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  names: readonly string[],
+): string | undefined | null {
+  for (const name of names) {
+    if (!Object.hasOwn(record, name)) continue
+    if (record[name] === undefined) return undefined
+    return typeof record[name] === "string" ? record[name] : null
+  }
+  return undefined
+}
+
+function optionalBoolean(
+  record: Record<string, unknown>,
+  names: readonly string[],
+): boolean | undefined | null {
+  for (const name of names) {
+    if (!Object.hasOwn(record, name)) continue
+    if (record[name] === undefined) return undefined
+    return typeof record[name] === "boolean" ? record[name] : null
+  }
+  return undefined
+}
+
+function optionalPositiveNumber(
+  record: Record<string, unknown>,
+  names: readonly string[],
+): number | undefined | null {
+  for (const name of names) {
+    if (!Object.hasOwn(record, name)) continue
+    const value = record[name]
+    if (value === undefined) return undefined
+    return typeof value === "number" && Number.isFinite(value) && value > 0
+      ? value
+      : null
+  }
+  return undefined
+}
+
+export function normalizeModelParameterValues(value: unknown): ModelParameterValue[] | null {
+  if (!Array.isArray(value)) return null
+  const parameters: ModelParameterValue[] = []
+  for (const parameter of value) {
+    if (!isPlainRecord(parameter)) return null
+    if (!isNonEmptyString(parameter.id) || typeof parameter.value !== "string") return null
+    parameters.push({ id: parameter.id, value: parameter.value })
+  }
+  return parameters
+}
+
+function normalizeVariant(value: unknown, fallbackName: string): ModelVariant | null {
+  if (!isPlainRecord(value)) return null
+  const parameters = normalizeModelParameterValues(
+    value.parameterValues ?? value.parameter_values ?? [],
+  )
+  if (!parameters) return null
+  const key = optionalString(value, ["key"])
+  const displayName = optionalString(value, ["displayName", "display_name"])
+  const isDefaultNonMax = optionalBoolean(
+    value,
+    ["isDefaultNonMax", "isDefaultNonMaxConfig", "is_default_non_max_config"],
+  )
+  const isDefaultMax = optionalBoolean(
+    value,
+    ["isDefaultMax", "isDefaultMaxConfig", "is_default_max_config"],
+  )
+  if (
+    key === null ||
+    displayName === null ||
+    isDefaultNonMax === null ||
+    isDefaultMax === null
+  ) {
+    return null
+  }
+  if (
+    (key !== undefined && !isNonEmptyString(key)) ||
+    (displayName !== undefined && !isNonEmptyString(displayName))
+  ) {
+    return null
+  }
+  return {
+    key: key ?? fallbackName,
+    displayName: displayName ?? fallbackName,
+    parameterValues: parameters,
+    isDefaultNonMax: isDefaultNonMax ?? false,
+    isDefaultMax: isDefaultMax ?? false,
+  }
+}
+
+function normalizeModelInfo(value: unknown): ModelInfo | null {
+  if (!isPlainRecord(value) || !isNonEmptyString(value.id)) return null
+  const rawVariants = value.variants ?? []
+  if (!Array.isArray(rawVariants)) return null
+  const variants = rawVariants.map((variant) => normalizeVariant(variant, value.id as string))
+  if (variants.some((variant) => variant === null)) return null
+
+  const displayName = optionalString(value, ["displayName", "display_name"])
+  const family = optionalString(value, ["family"])
+  const supportsThinking = optionalBoolean(value, ["supportsThinking", "supports_thinking"])
+  const supportsAgent = optionalBoolean(value, ["supportsAgent", "supports_agent"])
+  const supportsMaxMode = optionalBoolean(value, ["supportsMaxMode", "supports_max_mode"])
+  const maxContext = optionalPositiveNumber(
+    value,
+    ["maxContext", "contextTokenLimit", "context_token_limit"],
+  )
+  const maxContextForMaxMode = optionalPositiveNumber(
+    value,
+    ["maxContextForMaxMode", "contextTokenLimitForMaxMode", "context_token_limit_for_max_mode"],
+  )
+  if (
+    displayName === null ||
+    family === null ||
+    supportsThinking === null ||
+    supportsAgent === null ||
+    supportsMaxMode === null ||
+    maxContext === null ||
+    maxContextForMaxMode === null
+  ) {
+    return null
+  }
+  return {
+    id: value.id,
+    ...(displayName === undefined ? {} : { displayName }),
+    ...(family === undefined ? {} : { family }),
+    ...(supportsThinking === undefined ? {} : { supportsThinking }),
+    ...(supportsAgent === undefined ? {} : { supportsAgent }),
+    ...(maxContext === undefined ? {} : { maxContext }),
+    ...(maxContextForMaxMode === undefined ? {} : { maxContextForMaxMode }),
+    ...(supportsMaxMode === undefined ? {} : { supportsMaxMode }),
+    variants: variants as ModelVariant[],
+  }
+}
+
+export function normalizeModelCache(value: unknown): ModelCache | null {
+  if (!isPlainRecord(value) || !Array.isArray(value.models)) return null
+  if (typeof value.fetchedAt !== "number" || !Number.isFinite(value.fetchedAt)) return null
+  if (
+    value.schemaVersion !== undefined &&
+    (!Number.isSafeInteger(value.schemaVersion) || (value.schemaVersion as number) < 0)
+  ) {
+    return null
+  }
+  const models = value.models.map(normalizeModelInfo)
+  if (models.some((model) => model === null)) return null
+  return {
+    models: models as ModelInfo[],
+    fetchedAt: value.fetchedAt,
+    ...(value.schemaVersion === undefined
+      ? {}
+      : { schemaVersion: value.schemaVersion as number }),
+  }
+}
+
 /**
  * Read only the dedicated variant payload generated by the plugin. OpenCode
  * merges model, agent, and variant options into one providerOptions namespace;
@@ -51,15 +220,16 @@ export type ModelCache = {
 export function extractCursorVariantParameters(
   providerOptions: Record<string, unknown> | undefined,
 ): ModelParameterValue[] | undefined {
-  const raw = providerOptions?.[CURSOR_VARIANT_PARAMETERS_KEY]
-  if (!Array.isArray(raw) || raw.length === 0) return undefined
-
-  const params: ModelParameterValue[] = []
-  for (const item of raw) {
-    if (!item || typeof item !== "object" || Array.isArray(item)) return undefined
-    const { id, value } = item as Record<string, unknown>
-    if (typeof id !== "string" || typeof value !== "string") return undefined
-    params.push({ id, value })
+  if (!providerOptions || !Object.hasOwn(providerOptions, CURSOR_VARIANT_PARAMETERS_KEY)) {
+    return undefined
+  }
+  const params = normalizeModelParameterValues(
+    providerOptions[CURSOR_VARIANT_PARAMETERS_KEY],
+  )
+  if (!params) {
+    throw new CursorVariantSelectionError(
+      "is malformed: cursorVariantParameters must be a parameter array",
+    )
   }
   return params
 }
@@ -74,7 +244,11 @@ export function resolveCursorWireModelId(
 
 /** True when resolved params select the long-context (1m) tier. */
 export function paramsImplyMaxMode(params: ModelParameterValue[]): boolean {
-  return params.some((p) => p.id === "context" && p.value === "1m")
+  return params.some(
+    (parameter) =>
+      parameter.id === "context" &&
+      parseCursorContextLimit(parameter.value) === 1_000_000,
+  )
 }
 
 // Cursor encodes a model's context window as a variant parameter `id: "context"`
@@ -84,20 +258,28 @@ export function paramsImplyMaxMode(params: ModelParameterValue[]): boolean {
 // `context_token_limit` (#15) / `context_token_limit_for_max_mode` (#16) are
 // also defined on AvailableModel but the server often leaves them empty — the
 // variant param is the primary source (request flags may still populate them).
-const CONTEXT_TIER_TO_TOKENS: Record<string, number> = {
-  "200k": 200_000,
-  "272k": 272_000,
-  "300k": 300_000,
-  "1m": 1_000_000,
+export function parseCursorContextLimit(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined
+  const text = value.trim()
+  const match = /^(\d+(?:\.\d+)?)\s*([km])$/i.exec(text)
+  if (match) {
+    const multiplier = match[2]!.toLowerCase() === "k" ? 1_000 : 1_000_000
+    const limit = Number(match[1]) * multiplier
+    return Number.isSafeInteger(limit) && limit > 0 ? limit : undefined
+  }
+  const numeric = Number(text)
+  return Number.isSafeInteger(numeric) && numeric > 0 ? numeric : undefined
 }
 
 function variantContextTokens(v: ModelVariant | undefined): number | undefined {
   const raw = v?.parameterValues.find((p) => p.id === "context")?.value
-  if (!raw) return undefined
-  const mapped = CONTEXT_TIER_TO_TOKENS[raw]
-  if (mapped !== undefined) return mapped
-  const n = Number(raw)
-  return Number.isFinite(n) && n > 0 ? n : undefined
+  return parseCursorContextLimit(raw)
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined
 }
 
 // ── Cache helpers ──
@@ -114,21 +296,38 @@ export function cacheFilePath(cacheDir: string): string {
 export async function readCache(cacheDir: string): Promise<ModelCache | null> {
   const filePath = cacheFilePath(cacheDir)
   try {
-    if (!existsSync(filePath)) return null
     const data = await readFile(filePath, "utf-8")
-    return JSON.parse(data) as ModelCache
+    return normalizeModelCache(JSON.parse(data))
   } catch {
     return null
   }
 }
 
 export async function writeCache(cacheDir: string, cache: ModelCache): Promise<void> {
+  const normalized = normalizeModelCache(cache)
+  if (!normalized) throw new Error("Refusing to write an invalid Cursor model cache")
   const filePath = cacheFilePath(cacheDir)
-  await mkdir(path.dirname(filePath), { recursive: true })
-  await writeFile(filePath, JSON.stringify(cache, null, 2), "utf-8")
+  const directory = path.dirname(filePath)
+  const tempPath = path.join(
+    directory,
+    `.${MODEL_CACHE_FILE}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  )
+  await mkdir(directory, { recursive: true })
+  try {
+    await writeFile(tempPath, JSON.stringify(normalized, null, 2), "utf-8")
+    await rename(tempPath, filePath)
+  } finally {
+    await unlink(tempPath).catch(() => {})
+  }
 }
 
 // ── Map live API response to ModelInfo[] ──
+
+function apiBoolean(record: Record<string, unknown>, names: readonly string[]): boolean {
+  const value = optionalBoolean(record, names)
+  if (value === null) throw new Error(`AvailableModels returned a non-boolean ${names[0]}`)
+  return value ?? false
+}
 
 export function mapAvailableModelsResponse(
   raw: Record<string, unknown>,
@@ -137,24 +336,31 @@ export function mapAvailableModelsResponse(
   const models: ModelInfo[] = []
 
   for (const entry of entries) {
-    const e = entry as Record<string, unknown>
+    if (!isPlainRecord(entry)) continue
+    const e = entry
     const name = e.name as string | undefined
-    if (!name) continue
+    if (!isNonEmptyString(name)) continue
 
     const variants: ModelVariant[] = []
-    const rawVariants = (e.variants ?? []) as Record<string, unknown>[]
+    const rawVariants = e.variants ?? []
+    if (!Array.isArray(rawVariants)) {
+      throw new Error(`AvailableModels returned invalid variants for ${name}`)
+    }
     for (const v of rawVariants) {
+      if (!isPlainRecord(v)) {
+        throw new Error(`AvailableModels returned an invalid variant for ${name}`)
+      }
       const rawParams = (v.parameterValues ?? v.parameter_values ?? []) as Record<string, unknown>[]
-      const parameterValues: ModelParameterValue[] = rawParams.map((p) => ({
-        id: p.id as string,
-        value: String(p.value ?? ""),
-      }))
+      const parameterValues = normalizeModelParameterValues(rawParams)
+      if (!parameterValues) {
+        throw new Error(`AvailableModels returned invalid parameter values for ${name}`)
+      }
       variants.push({
         key: name,
         parameterValues,
         displayName: (v.displayName ?? v.display_name ?? name) as string,
-        isDefaultNonMax: !!(v.isDefaultNonMaxConfig ?? v.is_default_non_max_config ?? false),
-        isDefaultMax: !!(v.isDefaultMaxConfig ?? v.is_default_max_config ?? false),
+        isDefaultNonMax: apiBoolean(v, ["isDefaultNonMaxConfig", "is_default_non_max_config"]),
+        isDefaultMax: apiBoolean(v, ["isDefaultMaxConfig", "is_default_max_config"]),
       })
     }
 
@@ -176,11 +382,13 @@ export function mapAvailableModelsResponse(
     models.push({
       id: name,
       displayName: (e.clientDisplayName ?? e.client_display_name ?? name) as string,
-      supportsThinking: !!(e.supportsThinking ?? e.supports_thinking ?? false),
-      supportsAgent: !!(e.supportsAgent ?? e.supports_agent ?? false),
-      maxContext: (variantBaseContext ?? e.contextTokenLimit ?? e.context_token_limit ?? undefined) as number | undefined,
-      maxContextForMaxMode: (variantMaxContext ?? e.contextTokenLimitForMaxMode ?? e.context_token_limit_for_max_mode ?? undefined) as number | undefined,
-      supportsMaxMode: !!(e.supportsMaxMode ?? e.supports_max_mode ?? false),
+      supportsThinking: apiBoolean(e, ["supportsThinking", "supports_thinking"]),
+      supportsAgent: apiBoolean(e, ["supportsAgent", "supports_agent"]),
+      maxContext: variantBaseContext ?? positiveNumber(e.contextTokenLimit ?? e.context_token_limit),
+      maxContextForMaxMode:
+        variantMaxContext ??
+        positiveNumber(e.contextTokenLimitForMaxMode ?? e.context_token_limit_for_max_mode),
+      supportsMaxMode: apiBoolean(e, ["supportsMaxMode", "supports_max_mode"]),
       variants,
     })
   }
@@ -211,10 +419,14 @@ export function resolveVariantParameters(
     picked?: ModelParameterValue[]
   } = {},
 ): ModelParameterValue[] {
-  const picked = opts.picked?.length ? opts.picked.map((p) => ({ ...p })) : undefined
+  const picked = opts.picked?.map((p) => ({ ...p }))
 
   if (!model || model.variants.length === 0) {
-    if (picked?.length) return picked
+    if (picked !== undefined) {
+      throw new CursorVariantSelectionError(
+        `is stale: model ${JSON.stringify(model?.id ?? "unknown")} has no cached variants`,
+      )
+    }
     return opts.reasoningEffort ? [{ id: "effort", value: opts.reasoningEffort }] : []
   }
 
@@ -234,12 +446,15 @@ export function resolveVariantParameters(
   const scoped = pool.length > 0 ? pool : model.variants
 
   // 1. Variant explicitly picked by opencode (verbatim — preserves context, fast, …).
-  if (picked?.length) {
-    const signature = new Set(picked.map((p) => `${p.id}=${p.value}`))
+  if (picked !== undefined) {
     const exact = model.variants.find(
       (v) =>
-        v.parameterValues.every((p) => signature.has(`${p.id}=${p.value}`)) &&
-        signature.size === v.parameterValues.length,
+        v.parameterValues.length === picked.length &&
+        v.parameterValues.every(
+          (parameter, index) =>
+            parameter.id === picked[index]!.id &&
+            parameter.value === picked[index]!.value,
+        ),
     )
     if (exact) {
       return buildRequestedModelParams(exact.parameterValues, {
@@ -247,8 +462,9 @@ export function resolveVariantParameters(
         maxMode: wantMax,
       })
     }
-    // Unmatched: forward the stripped pick so the TUI choice is not discarded.
-    return picked
+    throw new CursorVariantSelectionError(
+      `is stale for model ${JSON.stringify(model.id)}: its exact parameter tuple is unavailable`,
+    )
   }
 
   // When maxMode is requested, prefer max-tier variants for effort matching
@@ -291,24 +507,45 @@ export async function fetchModels(
   return mapAvailableModelsResponse(raw)
 }
 
+const refreshesByDirectory = new Map<string, Promise<ModelInfo[]>>()
+
+export async function refreshModelCache(
+  cacheDir: string,
+  fetcher: () => Promise<ModelInfo[]>,
+): Promise<ModelInfo[]> {
+  const key = path.resolve(cacheDir)
+  const existing = refreshesByDirectory.get(key)
+  if (existing) return existing
+  const refresh = (async () => {
+    const models = await fetcher()
+    await writeCache(cacheDir, {
+      models,
+      fetchedAt: Date.now(),
+      schemaVersion: MODEL_CACHE_SCHEMA_VERSION,
+    })
+    return models
+  })()
+  refreshesByDirectory.set(key, refresh)
+  try {
+    return await refresh
+  } finally {
+    if (refreshesByDirectory.get(key) === refresh) refreshesByDirectory.delete(key)
+  }
+}
+
 export async function discoverModels(
   token: string,
   cacheDir: string,
   options: { baseURL?: string; headers?: Record<string, string> } = {},
 ): Promise<ModelInfo[]> {
   const cached = await readCache(cacheDir)
+  const refresh = () =>
+    refreshModelCache(cacheDir, () => fetchModels(token, options))
 
   // Cache is fresh → return it; refresh in background
   if (cached && isCacheFresh(cached)) {
     // Background refresh (fire and forget)
-    fetchModels(token, options)
-      .then((models) =>
-        writeCache(cacheDir, {
-          models,
-          fetchedAt: Date.now(),
-          schemaVersion: MODEL_CACHE_SCHEMA_VERSION,
-        }),
-      )
+    void refresh()
       .catch(() => {
         /* background refresh failure is non-fatal */
       })
@@ -318,26 +555,12 @@ export async function discoverModels(
   // Cache exists but expired → try fetch, serve stale on failure
   if (cached) {
     try {
-      const models = await fetchModels(token, options)
-      const newCache: ModelCache = {
-        models,
-        fetchedAt: Date.now(),
-        schemaVersion: MODEL_CACHE_SCHEMA_VERSION,
-      }
-      await writeCache(cacheDir, newCache)
-      return models
+      return await refresh()
     } catch {
       return cached.models
     }
   }
 
   // No cache → must fetch
-  const models = await fetchModels(token, options)
-  const newCache: ModelCache = {
-    models,
-    fetchedAt: Date.now(),
-    schemaVersion: MODEL_CACHE_SCHEMA_VERSION,
-  }
-  await writeCache(cacheDir, newCache)
-  return models
+  return refresh()
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -276,6 +276,10 @@ function variantContextTokens(v: ModelVariant | undefined): number | undefined {
   return parseCursorContextLimit(raw)
 }
 
+function isLongContextVariant(v: ModelVariant): boolean {
+  return variantContextTokens(v) === 1_000_000
+}
+
 function positiveNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? value
@@ -373,7 +377,7 @@ export function mapAvailableModelsResponse(
       variantContextTokens(variants.find((v) => v.isDefaultNonMax)) ??
       variantContextTokens(
         variants.find((v) =>
-          v.parameterValues.some((p) => p.id === "context" && p.value !== "1m"),
+          variantContextTokens(v) !== 1_000_000,
         ),
       ) ??
       variantContextTokens(variants.find((v) => v.parameterValues.some((p) => p.id === "context")))
@@ -434,10 +438,8 @@ export function resolveVariantParameters(
     v.parameterValues.find((p) => p.id === "effort" || p.id === "reasoning")?.value
   const isFast = (v: ModelVariant): boolean =>
     v.parameterValues.find((p) => p.id === "fast")?.value === "true"
-  const contextOf = (v: ModelVariant): string | undefined =>
-    v.parameterValues.find((p) => p.id === "context")?.value
   const isMaxVariant = (v: ModelVariant): boolean =>
-    v.isDefaultMax || contextOf(v) === "1m"
+    v.isDefaultMax || isLongContextVariant(v)
 
   const wantMax = opts.maxMode ?? false
   // Non-fast pool for hint-based resolution only. Exact `picked` matching
@@ -447,14 +449,12 @@ export function resolveVariantParameters(
 
   // 1. Variant explicitly picked by opencode (verbatim — preserves context, fast, …).
   if (picked !== undefined) {
+    const pickedById = new Map(picked.map((parameter) => [parameter.id, parameter.value]))
     const exact = model.variants.find(
       (v) =>
         v.parameterValues.length === picked.length &&
-        v.parameterValues.every(
-          (parameter, index) =>
-            parameter.id === picked[index]!.id &&
-            parameter.value === picked[index]!.value,
-        ),
+        pickedById.size === picked.length &&
+        v.parameterValues.every((parameter) => pickedById.get(parameter.id) === parameter.value),
     )
     if (exact) {
       return buildRequestedModelParams(exact.parameterValues, {
@@ -485,7 +485,7 @@ export function resolveVariantParameters(
 
   // 3. Max-mode hint → prefer the default max variant (1m context).
   if (wantMax) {
-    const max = scoped.find((v) => v.isDefaultMax) ?? scoped.find((v) => contextOf(v) === "1m")
+    const max = scoped.find((v) => v.isDefaultMax) ?? scoped.find(isLongContextVariant)
     if (max) return buildRequestedModelParams(max.parameterValues, { maxMode: true })
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,7 +2,7 @@ import type { Hooks, PluginInput, AuthOAuthResult, Config } from "@opencode-ai/p
 import type { Auth } from "@opencode-ai/sdk"
 import { CURSOR_COMPACTION_OPTION, CURSOR_PROVIDER_ID, CURSOR_WEBSITE_HOST, CURSOR_API_HOST } from "./shared.js"
 import { pollForTokens, exchangeApiKey, refreshAccessToken, isExpiringSoon, generatePkceParams, generatePkceChallenge, buildLoginUrl, decodeJwtPayload } from "./auth.js"
-import { CURSOR_VARIANT_PARAMETERS_KEY, CURSOR_WIRE_MODEL_ID_KEY, readCache, discoverModels, isCacheFresh, type ModelInfo, type ModelVariant } from "./models.js"
+import { CURSOR_VARIANT_PARAMETERS_KEY, CURSOR_WIRE_MODEL_ID_KEY, readCache, discoverModels, isCacheFresh, parseCursorContextLimit, type ModelInfo, type ModelVariant } from "./models.js"
 import { opencodeGlobalCacheDir } from "./context/paths.js"
 import { readStoredAuth, type StoredAuth } from "./context/auth-store.js"
 import { resolveAgentUrl } from "./agent-url.js"
@@ -98,7 +98,9 @@ function modelInfoVariants(
 }
 
 function isLongContextVariant(v: ModelVariant): boolean {
-  return v.parameterValues.some((p) => p.id === "context" && p.value === "1m")
+  return v.parameterValues.some(
+    (p) => p.id === "context" && parseCursorContextLimit(p.value) === 1_000_000,
+  )
 }
 
 function variantsForTier(mi: ModelInfo, tier: "base" | "long"): ModelVariant[] {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -389,6 +389,24 @@ describe("modelsToConfig (context-tier materialization)", () => {
     expect(paramsImplyMaxMode(resolved)).toBe(true)
   })
 
+  it("materializes an equivalent 1000k long-context label as the 1m tier", () => {
+    const equivalent = {
+      ...model,
+      variants: model.variants.map((variant) => ({
+        ...variant,
+        parameterValues: variant.parameterValues.map((parameter) =>
+          parameter.id === "context" && parameter.value === "1m"
+            ? { ...parameter, value: "1000k" }
+            : parameter,
+        ),
+      })),
+    }
+
+    const config = modelsToConfig([equivalent])
+    expect(Object.keys(config)).toEqual(["claude-opus-4-8", "claude-opus-4-8-1m"])
+    expect(Object.keys(config["claude-opus-4-8-1m"].variants)).toEqual(["Opus 4.8 1M High"])
+  })
+
   it("avoids collisions with a real model id ending in -1m", () => {
     const config = modelsToConfig([
       model,
@@ -520,7 +538,7 @@ describe("resolveVariantParameters (picked variant + max mode)", () => {
     expect(params.find((p) => p.id === "fast")?.value).toBe("false")
   })
 
-  it("rejects stale or reordered picked parameters instead of silently defaulting", () => {
+  it("rejects stale picked parameters without rejecting a reordered equivalent tuple", () => {
     const picked = [
       { id: "context", value: "999k" },
       { id: "effort", value: "ultra" },
@@ -528,7 +546,8 @@ describe("resolveVariantParameters (picked variant + max mode)", () => {
     expect(() => resolveVariantParameters(opus, { picked })).toThrow(/exact parameter tuple/)
 
     const valid = opus.variants[0]!.parameterValues
-    expect(() => resolveVariantParameters(opus, { picked: [...valid].reverse() })).toThrow(
+    expect(resolveVariantParameters(opus, { picked: [...valid].reverse() })).toEqual(valid)
+    expect(() => resolveVariantParameters(opus, { picked: [...valid, valid[0]!] })).toThrow(
       /exact parameter tuple/,
     )
   })

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,16 +1,41 @@
-import { describe, it, expect } from "bun:test"
+import { afterEach, describe, it, expect } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import {
   mapAvailableModelsResponse,
   isCacheFresh,
   cacheFilePath,
+  normalizeModelCache,
+  parseCursorContextLimit,
+  readCache,
+  refreshModelCache,
   resolveVariantParameters,
   paramsImplyMaxMode,
   extractCursorVariantParameters,
+  writeCache,
   CURSOR_VARIANT_PARAMETERS_KEY,
   CURSOR_WIRE_MODEL_ID_KEY,
   resolveCursorWireModelId,
+  type ModelCache,
 } from "../src/models.js"
 import { modelInfoToConfig, modelsToConfig } from "../src/plugin.js"
+
+const tempDirs: string[] = []
+
+async function tempDir(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cursor-provider-models-"))
+  tempDirs.push(directory)
+  return directory
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((directory) =>
+      fs.rm(directory, { recursive: true, force: true }),
+    ),
+  )
+})
 
 describe("mapAvailableModelsResponse", () => {
   it("returns empty array for empty models", () => {
@@ -49,6 +74,15 @@ describe("mapAvailableModelsResponse", () => {
     expect(models[0].variants).toHaveLength(1)
     expect(models[0].variants[0].parameterValues[0].id).toBe("effort")
     expect(models[0].variants[0].parameterValues[0].value).toBe("medium")
+  })
+
+  it("rejects non-string parameter values instead of coercing them", () => {
+    expect(() => mapAvailableModelsResponse({
+      models: [{
+        name: "invalid",
+        variants: [{ parameter_values: [{ id: "effort", value: true }] }],
+      }],
+    })).toThrow(/invalid parameter values/)
   })
 
   it("maps multiple model entries with multiple variants", () => {
@@ -486,12 +520,17 @@ describe("resolveVariantParameters (picked variant + max mode)", () => {
     expect(params.find((p) => p.id === "fast")?.value).toBe("false")
   })
 
-  it("forwards an unmatched picked paramMap instead of silently defaulting", () => {
+  it("rejects stale or reordered picked parameters instead of silently defaulting", () => {
     const picked = [
       { id: "context", value: "999k" },
       { id: "effort", value: "ultra" },
     ]
-    expect(resolveVariantParameters(opus, { picked })).toEqual(picked)
+    expect(() => resolveVariantParameters(opus, { picked })).toThrow(/exact parameter tuple/)
+
+    const valid = opus.variants[0]!.parameterValues
+    expect(() => resolveVariantParameters(opus, { picked: [...valid].reverse() })).toThrow(
+      /exact parameter tuple/,
+    )
   })
 })
 
@@ -518,10 +557,27 @@ describe("extractCursorVariantParameters", () => {
     })).toBeUndefined()
   })
 
-  it("rejects malformed dedicated payloads instead of stringifying objects", () => {
-    expect(extractCursorVariantParameters({
+  it("rejects malformed dedicated payloads instead of silently ignoring them", () => {
+    expect(() => extractCursorVariantParameters({
       [CURSOR_VARIANT_PARAMETERS_KEY]: [{ id: "thinking", value: { enabled: true } }],
-    })).toBeUndefined()
+    })).toThrow(/malformed/)
+  })
+
+  it("preserves an explicit empty tuple for a parameterless variant", () => {
+    const picked = extractCursorVariantParameters({
+      [CURSOR_VARIANT_PARAMETERS_KEY]: [],
+    })
+    expect(picked).toEqual([])
+    expect(resolveVariantParameters({
+      id: "parameterless",
+      variants: [{
+        key: "parameterless",
+        displayName: "Parameterless",
+        parameterValues: [],
+        isDefaultNonMax: true,
+        isDefaultMax: false,
+      }],
+    }, { picked })).toEqual([])
   })
 })
 
@@ -580,12 +636,118 @@ describe("mapAvailableModelsResponse (context tier edge cases)", () => {
     })
     expect(models[0].maxContext).toBeUndefined()
   })
+
+  it("treats zero-valued proto context defaults as absent", () => {
+    const models = mapAvailableModelsResponse({
+      models: [{
+        name: "zero-defaults",
+        context_token_limit: 0,
+        context_token_limit_for_max_mode: 0,
+        variants: [],
+      }],
+    })
+    expect(models[0].maxContext).toBeUndefined()
+    expect(models[0].maxContextForMaxMode).toBeUndefined()
+  })
 })
 
 describe("paramsImplyMaxMode", () => {
-  it("is true only for context=1m", () => {
+  it("recognizes equivalent one-million-token context labels", () => {
     expect(paramsImplyMaxMode([{ id: "context", value: "1m" }])).toBe(true)
+    expect(paramsImplyMaxMode([{ id: "context", value: "1000k" }])).toBe(true)
     expect(paramsImplyMaxMode([{ id: "context", value: "300k" }])).toBe(false)
     expect(paramsImplyMaxMode([])).toBe(false)
+  })
+})
+
+describe("parseCursorContextLimit", () => {
+  it("parses scalable context labels without a fixed tier table", () => {
+    expect(parseCursorContextLimit("200k")).toBe(200_000)
+    expect(parseCursorContextLimit("480K")).toBe(480_000)
+    expect(parseCursorContextLimit("2.5 M")).toBe(2_500_000)
+    expect(parseCursorContextLimit("1000000")).toBe(1_000_000)
+    expect(parseCursorContextLimit("auto")).toBeUndefined()
+    expect(parseCursorContextLimit("0m")).toBeUndefined()
+  })
+})
+
+function testCache(id = "cached"): ModelCache {
+  return {
+    fetchedAt: Date.now(),
+    schemaVersion: 2,
+    models: [{
+      id,
+      variants: [{
+        key: id,
+        displayName: id,
+        parameterValues: [{ id: "effort", value: "high" }],
+        isDefaultNonMax: true,
+        isDefaultMax: false,
+      }],
+    }],
+  }
+}
+
+describe("model cache integrity", () => {
+  it("rejects an entire malformed cache rather than exposing a partial catalog", async () => {
+    const directory = await tempDir()
+    const cache = testCache()
+    const malformed = {
+      ...cache,
+      models: [...cache.models, {
+        ...cache.models[0],
+        id: "bad",
+        variants: [{
+          ...cache.models[0]!.variants[0],
+          parameterValues: [{ id: "effort", value: true }],
+        }],
+      }],
+    }
+    await fs.writeFile(cacheFilePath(directory), JSON.stringify(malformed))
+
+    expect(normalizeModelCache(malformed)).toBeNull()
+    expect(await readCache(directory)).toBeNull()
+  })
+
+  it("writes atomically and preserves the previous cache after validation fails", async () => {
+    const directory = await tempDir()
+    const cache = testCache()
+    await writeCache(directory, cache)
+    const invalid = {
+      ...cache,
+      models: [{
+        ...cache.models[0],
+        variants: [{
+          ...cache.models[0]!.variants[0],
+          parameterValues: [{ id: "", value: "high" }],
+        }],
+      }],
+    } as unknown as ModelCache
+
+    await expect(writeCache(directory, invalid)).rejects.toThrow(/invalid Cursor model cache/)
+    expect(await readCache(directory)).toEqual(cache)
+    expect((await fs.readdir(directory)).filter((name) => name.includes(".tmp"))).toEqual([])
+  })
+
+  it("coalesces concurrent refreshes for the same cache directory", async () => {
+    const directory = await tempDir()
+    let fetches = 0
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const first = refreshModelCache(directory, async () => {
+      fetches++
+      await gate
+      return testCache("first").models
+    })
+    const second = refreshModelCache(directory, async () => {
+      fetches++
+      return testCache("second").models
+    })
+
+    expect(fetches).toBe(1)
+    release()
+    const [firstModels, secondModels] = await Promise.all([first, second])
+    expect(secondModels).toEqual(firstModels)
+    expect((await readCache(directory))?.models).toEqual(firstModels)
   })
 })


### PR DESCRIPTION
## Summary
Rebases / re-applies #11 onto `main` after #10 merged.

Original #11 (`vijankush:fix/model-hardening`) became conflicted because it still carried already-merged #9 commits. Unique commits cherry-picked cleanly onto current `main`:
- `fix: validate model caches and variant selections`
- `fix: normalize Cursor long context variants`

Closes #11.

## Test plan
- [x] Cherry-picks applied with no conflict markers
- [ ] CI / local tests as needed