### PR TITLE
fix: prevent Cursor startup hangs and Run control-plane deadlocks

### DIFF
--- a/src/agent-url.ts
+++ b/src/agent-url.ts
@@ -22,7 +22,14 @@ function normalizeApiBaseURL(baseURL: string | undefined): string {
   return new URL(baseURL).origin
 }
 
-function resolveCacheKey(token: string, options: { apiBaseURL?: string; baseURL?: string; telemetryEnabled?: boolean }): string {
+type AgentUrlOptions = {
+  apiBaseURL?: string
+  baseURL?: string
+  telemetryEnabled?: boolean
+  timeoutMs?: number
+}
+
+function resolveCacheKey(token: string, options: AgentUrlOptions): string {
   const tokenHash = createHash("sha256").update(token).digest("hex").slice(0, 16)
   return `${tokenHash}|${normalizeApiBaseURL(options.apiBaseURL ?? options.baseURL)}|telem:${options.telemetryEnabled === true}`
 }
@@ -43,7 +50,7 @@ const _inflight = new Map<string, Promise<string>>()
  */
 export async function resolveAgentUrl(
   token: string,
-  options: { apiBaseURL?: string; baseURL?: string; telemetryEnabled?: boolean } = {},
+  options: AgentUrlOptions = {},
 ): Promise<string> {
   const cacheKey = resolveCacheKey(token, options)
   const memo = _resolved.get(cacheKey)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import { CURSOR_API_HOST, CURSOR_WEBSITE_HOST } from "./shared.js"
 
 const API_BASE = `https://${CURSOR_API_HOST}`
+const AUTH_REQUEST_TIMEOUT_MS = 5_000
 
 export class AuthExchangeError extends Error {
   constructor(message: string, public cause?: unknown) {
@@ -82,49 +83,101 @@ export type TokenPair = {
   refreshToken: string
 }
 
+async function withAuthRequestDeadline<T>(
+  timeoutError: () => Error,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(timeoutError())
+      controller.abort()
+    }, AUTH_REQUEST_TIMEOUT_MS)
+    timer.unref?.()
+  })
+  try {
+    return await Promise.race([run(controller.signal), deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 export async function exchangeApiKey(
   apiKey: string,
   baseUrl = API_BASE,
 ): Promise<TokenPair> {
-  const res = await fetch(`${baseUrl}/auth/exchange_user_api_key`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+  return withAuthRequestDeadline(
+    () => new AuthExchangeError("API key exchange timed out"),
+    async (signal) => {
+      let res: Response
+      try {
+        res = await fetch(`${baseUrl}/auth/exchange_user_api_key`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: "{}",
+          signal,
+        })
+      } catch (cause) {
+        throw new AuthExchangeError("API key exchange request failed", cause)
+      }
+      if (!res.ok) {
+        throw new AuthExchangeError(
+          `API key exchange failed: ${res.status} ${res.statusText}`,
+        )
+      }
+      let body: Record<string, unknown>
+      try {
+        body = await res.json() as Record<string, unknown>
+      } catch (cause) {
+        throw new AuthExchangeError("API key exchange returned malformed JSON", cause)
+      }
+      if (typeof body.accessToken !== "string" || typeof body.refreshToken !== "string") {
+        throw new AuthExchangeError("Exchange response missing tokens")
+      }
+      return { accessToken: body.accessToken, refreshToken: body.refreshToken }
     },
-    body: "{}",
-  })
-  if (!res.ok) {
-    throw new AuthExchangeError(
-      `API key exchange failed: ${res.status} ${res.statusText}`,
-    )
-  }
-  const body = await res.json()
-  if (!body.accessToken || !body.refreshToken) {
-    throw new AuthExchangeError("Exchange response missing tokens")
-  }
-  return { accessToken: body.accessToken, refreshToken: body.refreshToken }
+  )
 }
 
 export async function refreshAccessToken(
   refreshToken: string,
   baseUrl = API_BASE,
 ): Promise<TokenPair> {
-  const res = await fetch(`${baseUrl}/auth/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken }),
-  })
-  if (!res.ok) {
-    throw new AuthRefreshError(
-      `Token refresh failed: ${res.status} ${res.statusText}`,
-    )
-  }
-  const body = await res.json()
-  if (!body.accessToken || !body.refreshToken) {
-    throw new AuthRefreshError("Refresh response missing tokens")
-  }
-  return { accessToken: body.accessToken, refreshToken: body.refreshToken }
+  return withAuthRequestDeadline(
+    () => new AuthRefreshError("Token refresh timed out"),
+    async (signal) => {
+      let res: Response
+      try {
+        res = await fetch(`${baseUrl}/auth/token`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refreshToken }),
+          signal,
+        })
+      } catch (cause) {
+        throw new AuthRefreshError("Token refresh request failed", cause)
+      }
+      if (!res.ok) {
+        throw new AuthRefreshError(
+          `Token refresh failed: ${res.status} ${res.statusText}`,
+        )
+      }
+      let body: Record<string, unknown>
+      try {
+        body = await res.json() as Record<string, unknown>
+      } catch (cause) {
+        throw new AuthRefreshError("Token refresh returned malformed JSON", cause)
+      }
+      if (typeof body.accessToken !== "string" || typeof body.refreshToken !== "string") {
+        throw new AuthRefreshError("Refresh response missing tokens")
+      }
+      return { accessToken: body.accessToken, refreshToken: body.refreshToken }
+    },
+  )
 }
 
 // Cache JWTs obtained via API-key exchange so doStream doesn't re-exchange

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,5 @@
 import { CURSOR_API_HOST, CURSOR_WEBSITE_HOST } from "./shared.js"
+import { withAbortDeadline } from "./deadline.js"
 
 const API_BASE = `https://${CURSOR_API_HOST}`
 const AUTH_REQUEST_TIMEOUT_MS = 5_000
@@ -83,31 +84,12 @@ export type TokenPair = {
   refreshToken: string
 }
 
-async function withAuthRequestDeadline<T>(
-  timeoutError: () => Error,
-  run: (signal: AbortSignal) => Promise<T>,
-): Promise<T> {
-  const controller = new AbortController()
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(timeoutError())
-      controller.abort()
-    }, AUTH_REQUEST_TIMEOUT_MS)
-    timer.unref?.()
-  })
-  try {
-    return await Promise.race([run(controller.signal), deadline])
-  } finally {
-    if (timer) clearTimeout(timer)
-  }
-}
-
 export async function exchangeApiKey(
   apiKey: string,
   baseUrl = API_BASE,
 ): Promise<TokenPair> {
-  return withAuthRequestDeadline(
+  return withAbortDeadline(
+    AUTH_REQUEST_TIMEOUT_MS,
     () => new AuthExchangeError("API key exchange timed out"),
     async (signal) => {
       let res: Response
@@ -147,7 +129,8 @@ export async function refreshAccessToken(
   refreshToken: string,
   baseUrl = API_BASE,
 ): Promise<TokenPair> {
-  return withAuthRequestDeadline(
+  return withAbortDeadline(
+    AUTH_REQUEST_TIMEOUT_MS,
     () => new AuthRefreshError("Token refresh timed out"),
     async (signal) => {
       let res: Response

--- a/src/deadline.ts
+++ b/src/deadline.ts
@@ -1,0 +1,27 @@
+/**
+ * Bound a complete async operation, not only fetch(). Response body readers can
+ * ignore abort signals, so Promise.race remains the authoritative deadline.
+ *
+ * Rejects with `timeoutError()` before aborting so callers observe the domain
+ * timeout error rather than a generic AbortError.
+ */
+export async function withAbortDeadline<T>(
+  timeoutMs: number,
+  timeoutError: () => Error,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(timeoutError())
+      controller.abort()
+    }, timeoutMs)
+    timer.unref?.()
+  })
+  try {
+    return await Promise.race([run(controller.signal), deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -38,7 +38,7 @@ import {
   resolveBridgedOpenCodeToolCall,
 } from "./protocol/tool-call-bridge.js"
 import { handleKvServerMessage } from "./protocol/kv.js"
-import { handleInteractionQuery, inspectInteractionQueryWire } from "./protocol/interactions.js"
+import { handleInteractionQuery } from "./protocol/interactions.js"
 import { getCheckpoint, setCheckpoint } from "./protocol/checkpoint.js"
 import { conversationBlobCount } from "./protocol/blob-store.js"
 import {
@@ -73,6 +73,8 @@ import {
   consumeCursorShellResult,
   registerCursorShellCall,
 } from "./shell-timeout.js"
+import { analyzeReplayFrame, AttemptReplaySafety } from "./replay-safety.js"
+import { readAllFieldsStrict } from "./protocol/struct.js"
 
 let _availableModels: ModelInfo[] | undefined
 // mtime of the cache file the last time we loaded it. Compared on each call
@@ -96,6 +98,34 @@ const DEFAULT_RETRY_POLICY = {
 } as const
 const MAX_RETRY_ATTEMPTS = 10
 const MAX_RETRY_DELAY_MS = 30_000
+const RUN_REQUEST_DECODE_FAILED = "CURSOR_RUN_REQUEST_DECODE_FAILED"
+const RUN_REQUEST_UNSUPPORTED = "CURSOR_RUN_REQUEST_UNSUPPORTED"
+const RUN_REPLY_FAILED = "CURSOR_RUN_REPLY_FAILED"
+
+type ResponseRequiredChannel = "exec" | "kv" | "interaction" | "multiple"
+const RESPONSE_REQUIRED_CHANNEL_BY_FIELD = new Map<
+  number,
+  Exclude<ResponseRequiredChannel, "multiple">
+>([
+  [2, "exec"],
+  [4, "kv"],
+  [7, "interaction"],
+])
+
+function responseRequiredChannel(payload: Uint8Array): ResponseRequiredChannel | undefined {
+  const fields = readAllFieldsStrict(payload)
+  if (fields) {
+    const channels = fields
+      .map((field) => RESPONSE_REQUIRED_CHANNEL_BY_FIELD.get(field.fn))
+      .filter((channel): channel is Exclude<ResponseRequiredChannel, "multiple"> => !!channel)
+    if (channels.length > 1) return "multiple"
+    return channels[0]
+  }
+
+  // Request tags are single-byte because all must-reply top-level fields are <16.
+  const tag = payload[0]
+  return tag !== undefined ? RESPONSE_REQUIRED_CHANNEL_BY_FIELD.get(tag >> 3) : undefined
+}
 
 export type CursorRetryPolicy = {
   maxAttempts: number
@@ -990,7 +1020,13 @@ export async function pump(
   let textStarted = false
   let reasoningStarted = false
   const requestUsage = ids.requestUsage ?? { outputChars: 0 }
-  let replaySafe = true
+  const replaySafety = new AttemptReplaySafety(session.sessionId)
+  const failRunProtocol = (message: string, code: string): never => {
+    replaySafety.markBarrier("unknown-or-malformed-frame")
+    const error = new CursorProtocolError(message, { code })
+    sessionManager.close(session, "remote-error", error)
+    throw error
+  }
   // OpenCode cancels the ReadableStream between turns (see the cancel handler
   // in doStreamImpl). The frames iterator can still yield a final `done` after
   // the cancel lands — controller.enqueue on a cancelled controller throws.
@@ -1113,7 +1149,7 @@ export async function pump(
 
   const emitText = (text: string) => {
     if (!text) return
-    replaySafe = false
+    replaySafety.markBarrier("visible-text")
     // Close reasoning before text (hosts expect reasoning-end before text-start).
     if (reasoningStarted && !textStarted) {
       safeEnqueue({ type: "reasoning-end", id: reasoningId } as V3Part)
@@ -1130,7 +1166,7 @@ export async function pump(
   }
   const emitReasoning = (text: string) => {
     if (!text) return
-    replaySafe = false
+    replaySafety.markBarrier("visible-reasoning")
     if (!reasoningStarted) {
       safeEnqueue({ type: "reasoning-start", id: reasoningId } as V3Part)
       reasoningStarted = true
@@ -1217,15 +1253,13 @@ export async function pump(
             `Cursor Run frame stream interrupted: ${(error as Error).message}`,
             { cause: error },
           )
-      failure.replaySafe = replaySafe && failure.replaySafe
-      throw failure
+      throw replaySafety.applyTo(failure)
     }
     if (next.done) {
       closeOpenSpans()
       trace("pump: frames iterator ended before turn_ended")
       const failure = new CursorRunInterruptedError()
-      failure.replaySafe = replaySafe
-      throw failure
+      throw replaySafety.applyTo(failure)
     }
     const frame = next.value as Frame
 
@@ -1237,14 +1271,15 @@ export async function pump(
       if (frame.payload.length > 0) {
         try {
           payload = new TextDecoder().decode(decodeFramePayload(frame))
-        } catch { /* not decodable */ }
+        } catch {
+          replaySafety.markBarrier("unknown-or-malformed-frame")
+        }
       }
       closeOpenSpans()
       const failure = payload
         ? connectFrameError(payload)
         : new CursorRunInterruptedError()
-      failure.replaySafe = replaySafe && failure.replaySafe
-      throw failure
+      throw replaySafety.applyTo(failure)
     }
 
     // decodeFramePayload can throw on a corrupt gzip payload (gunzipSync).
@@ -1253,49 +1288,54 @@ export async function pump(
     try {
       payload = decodeFramePayload(frame)
     } catch (e) {
+      replaySafety.markBarrier("unknown-or-malformed-frame")
       trace(`gunzip FAILED (skipping frame): flags=0x${frame.flags.toString(16)} len=${frame.payload.length} err=${(e as Error).message}`)
       continue
     }
     let asm: Record<string, unknown>
     try {
       asm = decodeMessage<Record<string, unknown>>("AgentServerMessage", payload)
-    } catch (e) {
+    } catch {
       // A single malformed/truncated frame must not abort the whole turn
       // (protobufjs throws "index out of range: …" on length overruns). Log it
       // and keep pumping.
-      replaySafe = false
-      const preview = Array.from(payload.subarray(0, 32))
-        .map((x) => x.toString(16).padStart(2, "0"))
-        .join("")
-      trace(
-        `decode FAILED (skipping): flags=0x${frame.flags.toString(16)} len=${payload.length} ` +
-          `topField=${payload.length ? payload[0] >> 3 : "-"} err=${(e as Error).message} hex=${preview}`,
-      )
+      replaySafety.markBarrier("unknown-or-malformed-frame")
+      const channel = responseRequiredChannel(payload)
+      if (channel) {
+        failRunProtocol(`Cursor ${channel} request could not be decoded`, RUN_REQUEST_DECODE_FAILED)
+      }
+      trace(`decode FAILED (skipping non-request frame): flags=0x${frame.flags.toString(16)} len=${payload.length}`)
       continue
     }
     const iu = asm.interaction_update as Record<string, unknown> | undefined
     const esm = asm.exec_server_message as Record<string, unknown> | undefined
     const kv = asm.kv_server_message as Record<string, unknown> | undefined
+    const execControl = asm.exec_server_control_message as Record<string, unknown> | undefined
     const interactionQuery = asm.interaction_query as Record<string, unknown> | undefined
     const checkpointRaw = asm.conversation_checkpoint_update
     const topField = payload.length > 0 ? payload[0] >> 3 : 0
-    const textProgress = (iu?.text_delta as Record<string, unknown> | undefined)?.text
-    const thinkingProgress = (iu?.thinking_delta as Record<string, unknown> | undefined)?.text
     const checkpointProgress = normalizeCheckpointBytes(checkpointRaw)
+    const requiredChannel = responseRequiredChannel(payload)
     if (
-      (typeof textProgress === "string" && textProgress.length > 0) ||
-      (typeof thinkingProgress === "string" && thinkingProgress.length > 0) ||
-      !!iu?.turn_ended ||
-      !!iu?.tool_call_started ||
-      !!iu?.tool_call_completed ||
-      !!esm ||
-      !!kv ||
-      !!interactionQuery ||
-      !!checkpointProgress?.length
+      requiredChannel === "multiple" ||
+      (requiredChannel === "exec" && !esm) ||
+      (requiredChannel === "kv" && !kv) ||
+      (requiredChannel === "interaction" && !interactionQuery)
     ) {
-      replaySafe = false
+      failRunProtocol("Cursor response-requiring request could not be decoded", RUN_REQUEST_DECODE_FAILED)
+    }
+    const replayFrame = analyzeReplayFrame(payload, {
+      interactionUpdate: iu,
+      exec: esm,
+      kv,
+      execControl,
+      interactionQuery,
+      checkpointBytes: checkpointProgress,
+    })
+    if (replayFrame.semanticProgress) {
       sessionManager.recordSemanticProgress(session)
     }
+    if (replayFrame.barrier) replaySafety.markBarrier(replayFrame.barrier)
 
     {
       const iuKind = iu ? Object.keys(iu).find((k) => iu[k]) : undefined
@@ -1435,14 +1475,8 @@ export async function pump(
           )
           session.stream.write(buildRequestContextResult(esmId, session.requestContext))
           trace(`exec request_context: replied`)
-        } catch (e) {
-          const error = new Error(
-            `Failed to answer Cursor request_context probe: ${(e as Error).message}`,
-          )
-          trace(`exec request_context: write FAILED ${error.message}`)
-          safeError(error)
-          sessionManager.close(session)
-          return
+        } catch {
+          failRunProtocol("Cursor request-context reply failed", RUN_REPLY_FAILED)
         }
       } else if (esm.mcp_state_exec_args) {
         // MCP-backed writes/reads can be preceded by this control-plane probe.
@@ -1455,14 +1489,11 @@ export async function pump(
         try {
           session.stream.write(buildMcpStateResult(esmId, stateArgs, session.requestContext))
           trace(`exec mcp_state: replied id=${esmId} requested=[${requested}]`)
-        } catch (e) {
-          const error = new Error(`Failed to answer Cursor MCP state probe: ${(e as Error).message}`)
-          trace(`exec mcp_state: write FAILED ${error.message}`)
-          safeError(error)
-          sessionManager.close(session)
-          return
+        } catch {
+          failRunProtocol("Cursor MCP-state reply failed", RUN_REPLY_FAILED)
         }
       } else {
+        replaySafety.markBarrier("non-control-exec")
         const parsed = parseExecServerMessage(esm)
         if (parsed) {
           const executableToolName = resolveCustomWebToolAlias(parsed.toolName, session.toolAliases)
@@ -1554,35 +1585,34 @@ export async function pump(
         trace(
           `exec UNMAPPED: id=${esmId} variant=${variantDescription} keys=[${Object.keys(esm).join(",")}] hex=${hex}`,
         )
-        const err = new Error(
+        failRunProtocol(
           `Unsupported Cursor exec variant ${variantDescription} (id=${esmId})`,
+          RUN_REQUEST_UNSUPPORTED,
         )
-        safeError(err)
-        sessionManager.close(session)
-        return
       }
     } else if (interactionQuery) {
       // InteractionQuery is a must-reply channel, just like exec and KV. AI
       // SDK has no Cursor-specific UI callback, so answer immediately with the
       // conservative headless policy from protocol/interactions.ts (including
       // F14 create_plan auto-ack / empty plan_uri for CLI headless parity).
+      const handled = (() => {
+        try {
+          return handleInteractionQuery(interactionQuery, payload)
+        } catch {
+          return failRunProtocol("Cursor interaction request could not be handled", RUN_REQUEST_UNSUPPORTED)
+        }
+      })()
       try {
-        const handled = handleInteractionQuery(interactionQuery, payload)
+        if (handled.outcome === "acknowledged") {
+          replaySafety.markBarrier("stateful-interaction")
+        }
         session.stream.write(handled.reply)
         trace(
           `interaction_query: replied id=${handled.id} variant=${handled.variantName} ` +
             `field=${handled.variantField} outcome=${handled.outcome}`,
         )
-      } catch (e) {
-        const info = inspectInteractionQueryWire(payload)
-        const err = e instanceof Error ? e : new Error(String(e))
-        trace(
-          `interaction_query: FAILED id=${info.id ?? "?"} ` +
-            `variantField=${info.variantField ?? "?"} err=${err.message}`,
-        )
-        safeError(err)
-        sessionManager.close(session)
-        return
+      } catch {
+        failRunProtocol("Cursor interaction reply failed", RUN_REPLY_FAILED)
       }
     } else if (kv) {
       // KV blob channel: ack set_blob / answer get_blob, then keep pumping.
@@ -1602,20 +1632,22 @@ export async function pump(
             `kv replied: kind=${handled.kind} id=${handled.id} blobId=${handled.blobIdHex.slice(0, 16)}… ` +
               `found=${handled.found} echoed=${!!handled.echoed} ` +
               `sessionBlobs=${session.blobs.size} convBlobs=${conversationBlobCount(session.conversationId)}`,
-            )
-        } catch (e) {
-          const error = new Error(`Failed to answer Cursor KV blob request: ${(e as Error).message}`)
-          trace(`kv: write FAILED ${error.message}`)
-          safeError(error)
-          sessionManager.close(session)
-          return
+          )
+        } catch {
+          failRunProtocol("Cursor KV reply failed", RUN_REPLY_FAILED)
         }
+      } else {
+        failRunProtocol("Cursor KV request could not be handled", RUN_REQUEST_UNSUPPORTED)
       }
     }
     } catch (e) {
+      if (e instanceof CursorProtocolError) throw e
+      if (requiredChannel) {
+        failRunProtocol(`Cursor ${requiredChannel} request could not be handled`, RUN_REQUEST_UNSUPPORTED)
+      }
       // Any per-frame dispatch throw (e.g. protobufjs length overrun in
       // exec/args decode) must not abort the whole turn — log and skip.
-      trace(`frame dispatch FAILED (skipping): topField=${topField} err=${(e as Error).message}`)
+      trace(`frame dispatch FAILED (skipping): topField=${topField}`)
     }
     // heartbeat / step / partial_tool_call → ignore (partial args are
     // display-only; the exec channel is authoritative. Checkpoints and

--- a/src/models.ts
+++ b/src/models.ts
@@ -501,7 +501,7 @@ export function resolveVariantParameters(
 
 export async function fetchModels(
   token: string,
-  options: { baseURL?: string; headers?: Record<string, string> } = {},
+  options: { baseURL?: string; headers?: Record<string, string>; timeoutMs?: number } = {},
 ): Promise<ModelInfo[]> {
   const raw = await unaryAvailableModels(token, options)
   return mapAvailableModelsResponse(raw)
@@ -536,7 +536,7 @@ export async function refreshModelCache(
 export async function discoverModels(
   token: string,
   cacheDir: string,
-  options: { baseURL?: string; headers?: Record<string, string> } = {},
+  options: { baseURL?: string; headers?: Record<string, string>; timeoutMs?: number } = {},
 ): Promise<ModelInfo[]> {
   const cached = await readCache(cacheDir)
   const refresh = () =>

--- a/src/protocol/client-version.ts
+++ b/src/protocol/client-version.ts
@@ -6,6 +6,7 @@ import {
   VERSION_CACHE_FILE,
 } from "../shared.js"
 import { opencodeGlobalCacheDir } from "../context/paths.js"
+import { withAbortDeadline } from "../deadline.js"
 
 const INSTALL_URL = "https://cursor.com/install"
 const REMOTE_TIMEOUT_MS = 5_000
@@ -128,29 +129,17 @@ function isCacheFresh(cache: VersionCache, now = Date.now()): boolean {
 }
 
 async function fetchInstallerVersion(): Promise<string | undefined> {
-  const controller = new AbortController()
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error("Cursor installer version request timed out"))
-      controller.abort()
-    }, REMOTE_TIMEOUT_MS)
-    timer.unref?.()
-  })
-  try {
-    return await Promise.race([
-      (async () => {
-        const response = await fetch(INSTALL_URL, { signal: controller.signal })
-        if (!response.ok) return undefined
+  return withAbortDeadline(
+    REMOTE_TIMEOUT_MS,
+    () => new Error("Cursor installer version request timed out"),
+    async (signal) => {
+      const response = await fetch(INSTALL_URL, { signal })
+      if (!response.ok) return undefined
 
-        const build = extractVersionFromInstaller(await response.text())
-        return build ? `cli-${build}` : undefined
-      })(),
-      deadline,
-    ])
-  } finally {
-    if (timer) clearTimeout(timer)
-  }
+      const build = extractVersionFromInstaller(await response.text())
+      return build ? `cli-${build}` : undefined
+    },
+  )
 }
 
 async function refreshVersionCache(): Promise<void> {

--- a/src/protocol/client-version.ts
+++ b/src/protocol/client-version.ts
@@ -128,13 +128,29 @@ function isCacheFresh(cache: VersionCache, now = Date.now()): boolean {
 }
 
 async function fetchInstallerVersion(): Promise<string | undefined> {
-  const response = await fetch(INSTALL_URL, {
-    signal: AbortSignal.timeout(REMOTE_TIMEOUT_MS),
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error("Cursor installer version request timed out"))
+      controller.abort()
+    }, REMOTE_TIMEOUT_MS)
+    timer.unref?.()
   })
-  if (!response.ok) return undefined
+  try {
+    return await Promise.race([
+      (async () => {
+        const response = await fetch(INSTALL_URL, { signal: controller.signal })
+        if (!response.ok) return undefined
 
-  const build = extractVersionFromInstaller(await response.text())
-  return build ? `cli-${build}` : undefined
+        const build = extractVersionFromInstaller(await response.text())
+        return build ? `cli-${build}` : undefined
+      })(),
+      deadline,
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
 }
 
 async function refreshVersionCache(): Promise<void> {

--- a/src/protocol/struct.ts
+++ b/src/protocol/struct.ts
@@ -86,6 +86,105 @@ export function readAllFields(b: Uint8Array): RawField[] {
   return out
 }
 
+export type StrictRawField = {
+  fn: number
+  wt: number
+  varint?: bigint
+  bytes?: Uint8Array
+  fixed64?: Uint8Array
+  fixed32?: Uint8Array
+}
+
+type DecodedVarint = { value: bigint; nextOffset: number }
+
+const MAX_UINT32 = 0xffff_ffffn
+const MAX_UINT64 = 0xffff_ffff_ffff_ffffn
+const MAX_PROTOBUF_FIELD_NUMBER = 0x1fff_ffff
+
+/**
+ * Decode one unsigned protobuf varint without JavaScript's 32-bit bitwise
+ * truncation. `maximum` also enforces the protocol width: tags and lengths are
+ * uint32, while wire-type 0 scalar values may use the full uint64 range.
+ */
+function readBoundedVarint(
+  bytes: Uint8Array,
+  offset: number,
+  maximum: bigint,
+): DecodedVarint | undefined {
+  let value = 0n
+  let shift = 0n
+  for (let index = offset; index < bytes.length && index < offset + 10; index++) {
+    const byte = bytes[index]!
+    value |= BigInt(byte & 0x7f) << shift
+    if (value > maximum) return undefined
+    if ((byte & 0x80) === 0) return { value, nextOffset: index + 1 }
+    shift += 7n
+  }
+  return undefined
+}
+
+/**
+ * Strictly walk a protobuf message for security/replay decisions.
+ *
+ * Unlike `readAllFields`, this parser consumes the complete input, preserves
+ * uint64 varints as bigint, represents fixed-width fields, and rejects invalid
+ * tags, truncation, overflow, groups, and unsupported wire types. It deliberately
+ * returns `undefined` instead of a partial result: callers must fail closed when
+ * deciding whether replay is safe.
+ */
+export function readAllFieldsStrict(bytes: Uint8Array): StrictRawField[] | undefined {
+  let offset = 0
+  const fields: StrictRawField[] = []
+
+  while (offset < bytes.length) {
+    const tag = readBoundedVarint(bytes, offset, MAX_UINT32)
+    if (!tag) return undefined
+    offset = tag.nextOffset
+
+    const fieldNumber = Number(tag.value >> 3n)
+    const wireType = Number(tag.value & 7n)
+    if (fieldNumber === 0 || fieldNumber > MAX_PROTOBUF_FIELD_NUMBER) return undefined
+
+    if (wireType === 0) {
+      const scalar = readBoundedVarint(bytes, offset, MAX_UINT64)
+      if (!scalar) return undefined
+      fields.push({ fn: fieldNumber, wt: wireType, varint: scalar.value })
+      offset = scalar.nextOffset
+      continue
+    }
+
+    if (wireType === 1) {
+      if (offset + 8 > bytes.length) return undefined
+      fields.push({ fn: fieldNumber, wt: wireType, fixed64: bytes.subarray(offset, offset + 8) })
+      offset += 8
+      continue
+    }
+
+    if (wireType === 2) {
+      const encodedLength = readBoundedVarint(bytes, offset, MAX_UINT32)
+      if (!encodedLength) return undefined
+      offset = encodedLength.nextOffset
+      const length = Number(encodedLength.value)
+      if (offset + length > bytes.length) return undefined
+      fields.push({ fn: fieldNumber, wt: wireType, bytes: bytes.subarray(offset, offset + length) })
+      offset += length
+      continue
+    }
+
+    if (wireType === 5) {
+      if (offset + 4 > bytes.length) return undefined
+      fields.push({ fn: fieldNumber, wt: wireType, fixed32: bytes.subarray(offset, offset + 4) })
+      offset += 4
+      continue
+    }
+
+    // Groups (3/4) are deprecated and recursive; no replay-safe frame uses them.
+    return undefined
+  }
+
+  return fields
+}
+
 function decodeStructBytes(b: Uint8Array): Record<string, unknown> {
   const obj: Record<string, unknown> = {}
   for (const f of readAllFields(b)) {

--- a/src/replay-safety.ts
+++ b/src/replay-safety.ts
@@ -1,0 +1,169 @@
+import type { CursorProviderError } from "./errors.js"
+import { trace } from "./debug.js"
+import { readAllFieldsStrict, type StrictRawField } from "./protocol/struct.js"
+
+export type ReplayBarrierReason =
+  | "visible-text"
+  | "visible-reasoning"
+  | "display-tool-lifecycle"
+  | "non-control-exec"
+  | "stateful-interaction"
+  | "unknown-or-malformed-frame"
+
+export class AttemptReplaySafety {
+  private barrierReason: ReplayBarrierReason | undefined
+
+  constructor(private readonly sessionId: string) {}
+
+  markBarrier(reason: ReplayBarrierReason): void {
+    if (this.barrierReason) return
+    this.barrierReason = reason
+    trace(`replay barrier: reason=${reason} sessionId=${this.sessionId}`)
+  }
+
+  applyTo(failure: CursorProviderError): CursorProviderError {
+    failure.replaySafe = this.barrierReason === undefined && failure.replaySafe
+    if (this.barrierReason) {
+      trace(`replay suppressed: reason=${this.barrierReason} sessionId=${this.sessionId}`)
+    }
+    return failure
+  }
+}
+
+export type DecodedReplayFrame = {
+  interactionUpdate?: Record<string, unknown>
+  exec?: Record<string, unknown>
+  kv?: Record<string, unknown>
+  execControl?: Record<string, unknown>
+  interactionQuery?: Record<string, unknown>
+  checkpointBytes?: Uint8Array
+}
+
+export type ReplayFrameAnalysis = {
+  semanticProgress: boolean
+  barrier?: ReplayBarrierReason
+}
+
+const INTERACTION_UPDATE_FIELDS = new Set([1, 2, 3, 4, 7, 13, 14, 16, 17])
+const INTERACTION_QUERY_FIELDS = new Set([2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14])
+const TOP_LEVEL_FIELDS = new Set([1, 2, 3, 4, 5, 7])
+
+function nestedFields(topLevel: StrictRawField | undefined, field: number): StrictRawField[] {
+  if (topLevel?.fn !== field || topLevel.wt !== 2 || !topLevel.bytes) return []
+  return readAllFieldsStrict(topLevel.bytes) ?? []
+}
+
+function analyzeExecWire(topLevel: StrictRawField | undefined) {
+  const variants = nestedFields(topLevel, 2)
+    .filter((field) => ![1, 15, 19].includes(field.fn))
+  const exactVariant = (field: number): boolean =>
+    variants.length === 1 && variants[0]!.fn === field && variants[0]!.wt === 2
+  return {
+    exactRequestContext: exactVariant(10),
+    exactMcpState: exactVariant(36),
+  }
+}
+
+function validKvWire(topLevel: StrictRawField | undefined): boolean {
+  const variants = nestedFields(topLevel, 4).filter((field) => field.fn !== 1)
+  const variant = variants.length === 1 ? variants[0] : undefined
+  const args = variant?.wt === 2 && variant.bytes
+    ? (readAllFieldsStrict(variant.bytes) ?? [])
+    : []
+  const blobIds = args.filter(
+    (field) => field.fn === 1 && field.wt === 2 && (field.bytes?.length ?? 0) > 0,
+  )
+  return !!variant
+    && [2, 3].includes(variant.fn)
+    && variant.wt === 2
+    && blobIds.length === 1
+    && args.every(
+      (field) => field.wt === 2 && (field.fn === 1 || (variant.fn === 3 && field.fn === 2)),
+    )
+}
+
+function validInteractionUpdateWire(
+  topLevel: StrictRawField | undefined,
+  decoded: Record<string, unknown> | undefined,
+): boolean {
+  if (!decoded) return true
+  const fields = nestedFields(topLevel, 1)
+  const update = fields.length === 1 ? fields[0] : undefined
+  if (!update || update.wt !== 2 || !INTERACTION_UPDATE_FIELDS.has(update.fn)) return false
+  if (![1, 4].includes(update.fn)) return true
+  const delta = update.bytes ? (readAllFieldsStrict(update.bytes) ?? []) : []
+  return delta.length === 1 && delta[0]!.fn === 1 && delta[0]!.wt === 2
+}
+
+function validInteractionQueryWire(
+  topLevel: StrictRawField | undefined,
+  decoded: Record<string, unknown> | undefined,
+): boolean {
+  if (!decoded) return true
+  const fields = nestedFields(topLevel, 7)
+  const ids = fields.filter((field) => field.fn === 1)
+  const variants = fields.filter((field) => field.fn !== 1)
+  return ids.length <= 1
+    && ids.every((field) => field.wt === 0)
+    && variants.length === 1
+    && variants[0]!.wt === 2
+    && INTERACTION_QUERY_FIELDS.has(variants[0]!.fn)
+}
+
+function decodedMatchesWire(topLevel: StrictRawField | undefined, decoded: DecodedReplayFrame): boolean {
+  return !(
+    (topLevel?.fn === 1 && !decoded.interactionUpdate)
+    || (topLevel?.fn === 2 && !decoded.exec)
+    || (topLevel?.fn === 4 && !decoded.kv)
+    || (topLevel?.fn === 5 && !decoded.execControl)
+    || (topLevel?.fn === 7 && !decoded.interactionQuery)
+  )
+}
+
+function hasSemanticProgress(decoded: DecodedReplayFrame): boolean {
+  const update = decoded.interactionUpdate
+  const text = (update?.text_delta as Record<string, unknown> | undefined)?.text
+  const thinking = (update?.thinking_delta as Record<string, unknown> | undefined)?.text
+  return (typeof text === "string" && text.length > 0)
+    || (typeof thinking === "string" && thinking.length > 0)
+    || !!update?.turn_ended
+    || !!update?.tool_call_started
+    || !!update?.tool_call_completed
+    || !!decoded.exec
+    || !!decoded.kv
+    || !!decoded.execControl
+    || !!decoded.interactionQuery
+    || !!decoded.checkpointBytes?.length
+}
+
+/** Classify one decoded server frame without performing any protocol side effects. */
+export function analyzeReplayFrame(
+  payload: Uint8Array,
+  decoded: DecodedReplayFrame,
+): ReplayFrameAnalysis {
+  const topLevelFields = readAllFieldsStrict(payload) ?? []
+  const topLevel = topLevelFields.length === 1 ? topLevelFields[0] : undefined
+  const exec = analyzeExecWire(topLevel)
+  const validKv = validKvWire(topLevel)
+  const malformed = !topLevel
+    || topLevel.wt !== 2
+    || !TOP_LEVEL_FIELDS.has(topLevel.fn)
+    || !validInteractionUpdateWire(topLevel, decoded.interactionUpdate)
+    || !validInteractionQueryWire(topLevel, decoded.interactionQuery)
+    || !decodedMatchesWire(topLevel, decoded)
+    || !!decoded.execControl
+
+  let barrier: ReplayBarrierReason | undefined
+  if (decoded.interactionUpdate?.tool_call_started || decoded.interactionUpdate?.tool_call_completed) {
+    barrier = "display-tool-lifecycle"
+  } else if (malformed || (topLevel.fn === 4 && !validKv)) {
+    barrier = "unknown-or-malformed-frame"
+  } else if (topLevel.fn === 2 && !exec.exactRequestContext && !exec.exactMcpState) {
+    barrier = "non-control-exec"
+  }
+
+  return {
+    semanticProgress: hasSemanticProgress(decoded),
+    barrier,
+  }
+}

--- a/src/transport/connect.ts
+++ b/src/transport/connect.ts
@@ -16,6 +16,49 @@ import {
 import http2 from "node:http2"
 
 const API_BASE = `https://${CURSOR_API_HOST}`
+const DEFAULT_UNARY_TIMEOUT_MS = 5_000
+const MAX_TIMER_MS = 2_147_483_647
+
+function unaryTimeoutMs(operation: string, value: number | undefined): number {
+  const timeoutMs = value ?? DEFAULT_UNARY_TIMEOUT_MS
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMER_MS) {
+    throw new CursorProtocolError(
+      `${operation} timeout must be a positive integer no greater than ${MAX_TIMER_MS}`,
+      { code: "CURSOR_INVALID_TIMEOUT" },
+    )
+  }
+  return timeoutMs
+}
+
+/**
+ * Bound a complete unary operation, not only fetch(). Response body readers can
+ * ignore abort signals, so Promise.race remains the authoritative deadline.
+ */
+async function withUnaryDeadline<T>(
+  operation: string,
+  timeoutMs: number,
+  timeoutCode: string,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new CursorTransportError(`${operation} timed out after ${timeoutMs}ms`, {
+        transient: true,
+        replaySafe: true,
+        code: timeoutCode,
+      }))
+      controller.abort()
+    }, timeoutMs)
+    timer.unref?.()
+  })
+  try {
+    return await Promise.race([run(controller.signal), deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
 
 function resolveApiBaseURL(options: { apiBaseURL?: string; baseURL?: string }): string {
   return new URL(options.apiBaseURL ?? options.baseURL ?? API_BASE).origin
@@ -49,47 +92,60 @@ export function buildBaseHeaders(
 
 export async function unaryAvailableModels(
   token: string,
-  options: { apiBaseURL?: string; baseURL?: string; headers?: Record<string, string> } = {},
+  options: {
+    apiBaseURL?: string
+    baseURL?: string
+    headers?: Record<string, string>
+    timeoutMs?: number
+  } = {},
 ): Promise<Record<string, unknown>> {
   const base = resolveApiBaseURL(options)
   const url = `${base}/aiserver.v1.AiService/AvailableModels`
-  const clientVersion = await resolveClientVersion()
-  const headers = buildBaseHeaders(token, clientVersion, options.headers)
+  const timeoutMs = unaryTimeoutMs("AvailableModels", options.timeoutMs)
+  return withUnaryDeadline(
+    "AvailableModels",
+    timeoutMs,
+    "CURSOR_AVAILABLE_MODELS_TIMEOUT",
+    async (signal) => {
+      const clientVersion = await resolveClientVersion()
+      const headers = buildBaseHeaders(token, clientVersion, options.headers)
+      let res: Response
+      try {
+        res = await fetch(url, {
+          method: "POST",
+          headers: {
+            ...headers,
+            "content-type": "application/json",
+            accept: "application/json",
+          },
+          // Request parameterized effort/context/fast variants like Cursor IDE.
+          body: JSON.stringify({
+            includeLongContextModels: true,
+            useModelParameters: true,
+            useCloudAgentEffortModes: true,
+          }),
+          signal,
+        })
+      } catch (cause) {
+        throw new CursorTransportError("AvailableModels network request failed", {
+          transient: true,
+          replaySafe: true,
+          code: errorCode(cause),
+          cause,
+        })
+      }
 
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: "POST",
-      headers: {
-        ...headers,
-        "content-type": "application/json",
-        accept: "application/json",
-      },
-      // Request parameterized effort/context/fast variants like Cursor IDE.
-      body: JSON.stringify({
-        includeLongContextModels: true,
-        useModelParameters: true,
-        useCloudAgentEffortModes: true,
-      }),
-    })
-  } catch (cause) {
-    throw new CursorTransportError("AvailableModels network request failed", {
-      transient: true,
-      replaySafe: true,
-      code: errorCode(cause),
-      cause,
-    })
-  }
+      if (!res.ok) {
+        throw await cursorHttpResponseError("AvailableModels failed:", res)
+      }
 
-  if (!res.ok) {
-    throw await cursorHttpResponseError("AvailableModels failed:", res)
-  }
-
-  try {
-    return (await res.json()) as Record<string, unknown>
-  } catch (cause) {
-    throw new CursorProtocolError("AvailableModels returned malformed JSON", { cause })
-  }
+      try {
+        return (await res.json()) as Record<string, unknown>
+      } catch (cause) {
+        throw new CursorProtocolError("AvailableModels returned malformed JSON", { cause })
+      }
+    },
+  )
 }
 
 // ── Unary (GetServerConfig) ──
@@ -135,60 +191,74 @@ export function normalizeAgentRunOrigin(raw: string | undefined): string | null 
  */
 export async function fetchAgentUrl(
   token: string,
-  options: { apiBaseURL?: string; baseURL?: string; telemetryEnabled?: boolean } = {},
+  options: {
+    apiBaseURL?: string
+    baseURL?: string
+    telemetryEnabled?: boolean
+    timeoutMs?: number
+  } = {},
 ): Promise<string> {
   const base = resolveApiBaseURL(options)
   const url = `${base}${SERVER_CONFIG_PATH}`
-  const clientVersion = await resolveClientVersion()
-  // Match Cursor CLI: GetServerConfig uses base headers only — session headers belong on Run.
-  const headers = buildBaseHeaders(token, clientVersion)
+  const timeoutMs = unaryTimeoutMs("GetServerConfig", options.timeoutMs)
+  return withUnaryDeadline(
+    "GetServerConfig",
+    timeoutMs,
+    "CURSOR_AGENT_URL_TIMEOUT",
+    async (signal) => {
+      const clientVersion = await resolveClientVersion()
+      // Match Cursor CLI: GetServerConfig uses base headers only — session headers belong on Run.
+      const headers = buildBaseHeaders(token, clientVersion)
 
-  trace(`GetServerConfig POST ${url}`)
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: "POST",
-      headers: {
-        ...headers,
-        "content-type": "application/json",
-        accept: "application/json",
-      },
-      body: JSON.stringify({ telem_enabled: options.telemetryEnabled ?? false }),
-    })
-  } catch (cause) {
-    throw new CursorTransportError("GetServerConfig network request failed", {
-      transient: true,
-      replaySafe: true,
-      code: errorCode(cause),
-      cause,
-    })
-  }
+      trace(`GetServerConfig POST ${url}`)
+      let res: Response
+      try {
+        res = await fetch(url, {
+          method: "POST",
+          headers: {
+            ...headers,
+            "content-type": "application/json",
+            accept: "application/json",
+          },
+          body: JSON.stringify({ telem_enabled: options.telemetryEnabled ?? false }),
+          signal,
+        })
+      } catch (cause) {
+        throw new CursorTransportError("GetServerConfig network request failed", {
+          transient: true,
+          replaySafe: true,
+          code: errorCode(cause),
+          cause,
+        })
+      }
 
-  if (!res.ok) {
-    throw await cursorHttpResponseError("GetServerConfig failed:", res)
-  }
+      if (!res.ok) {
+        throw await cursorHttpResponseError("GetServerConfig failed:", res)
+      }
 
-  let body: Record<string, unknown>
-  try {
-    body = (await res.json()) as Record<string, unknown>
-  } catch (cause) {
-    throw new CursorProtocolError("GetServerConfig returned malformed JSON", { cause })
-  }
-  const cfg = body.agentUrlConfig as { agentnUrl?: string; agentUrl?: string } | undefined
-  const raw = cfg?.agentnUrl || cfg?.agentUrl
-  const normalized = normalizeAgentRunOrigin(raw)
-  trace(
-    `GetServerConfig reply: agentnUrl=${cfg?.agentnUrl ?? "<missing>"} ` +
-      `agentUrl=${cfg?.agentUrl ?? "<missing>"} → ${normalized ?? "<invalid>"}`,
+      let body: Record<string, unknown>
+      try {
+        body = (await res.json()) as Record<string, unknown>
+      } catch (cause) {
+        throw new CursorProtocolError("GetServerConfig returned malformed JSON", { cause })
+      }
+      const cfg = body.agentUrlConfig as { agentnUrl?: string; agentUrl?: string } | undefined
+      const raw = cfg?.agentnUrl || cfg?.agentUrl
+      const normalized = normalizeAgentRunOrigin(raw)
+      trace(
+        `GetServerConfig reply: agentnUrl=${cfg?.agentnUrl ?? "<missing>"} ` +
+          `agentUrl=${cfg?.agentUrl ?? "<missing>"} → ${normalized ?? "<invalid>"}`,
+      )
+      if (!normalized) {
+        throw new CursorProtocolError(
+          raw
+            ? "GetServerConfig returned an invalid Cursor agent URL"
+            : "GetServerConfig response missing agentUrlConfig.agentnUrl",
+        )
+      }
+      return normalized
+    },
   )
-  if (!normalized) {
-    throw new CursorProtocolError(
-      raw
-        ? "GetServerConfig returned an invalid Cursor agent URL"
-        : "GetServerConfig response missing agentUrlConfig.agentnUrl",
-    )
-  }
-  return normalized
 }
 
 // ── Bidi (Run stream) ──
@@ -293,7 +363,6 @@ const CONNECT_TIMEOUT_MS = 15_000
 const DEFAULT_SESSION_PING_TIMEOUT_MS = 5_000
 const DEFAULT_READ_IDLE_MS = 120_000
 const WRITE_DRAIN_TIMEOUT_CODE = "CURSOR_WRITE_DRAIN_TIMEOUT"
-const MAX_TIMER_MS = 2_147_483_647
 export const HTTP2_SESSION_MAX_AGE_MS = 15 * 60_000
 
 export function shouldReuseHttp2Session(

--- a/src/transport/connect.ts
+++ b/src/transport/connect.ts
@@ -13,6 +13,7 @@ import {
   errorCode,
   CursorProviderError,
 } from "../errors.js"
+import { withAbortDeadline } from "../deadline.js"
 import http2 from "node:http2"
 
 const API_BASE = `https://${CURSOR_API_HOST}`
@@ -30,34 +31,21 @@ function unaryTimeoutMs(operation: string, value: number | undefined): number {
   return timeoutMs
 }
 
-/**
- * Bound a complete unary operation, not only fetch(). Response body readers can
- * ignore abort signals, so Promise.race remains the authoritative deadline.
- */
 async function withUnaryDeadline<T>(
   operation: string,
   timeoutMs: number,
   timeoutCode: string,
   run: (signal: AbortSignal) => Promise<T>,
 ): Promise<T> {
-  const controller = new AbortController()
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(new CursorTransportError(`${operation} timed out after ${timeoutMs}ms`, {
-        transient: true,
-        replaySafe: true,
-        code: timeoutCode,
-      }))
-      controller.abort()
-    }, timeoutMs)
-    timer.unref?.()
-  })
-  try {
-    return await Promise.race([run(controller.signal), deadline])
-  } finally {
-    if (timer) clearTimeout(timer)
-  }
+  return withAbortDeadline(
+    timeoutMs,
+    () => new CursorTransportError(`${operation} timed out after ${timeoutMs}ms`, {
+      transient: true,
+      replaySafe: true,
+      code: timeoutCode,
+    }),
+    run,
+  )
 }
 
 function resolveApiBaseURL(options: { apiBaseURL?: string; baseURL?: string }): string {

--- a/test/connect-origin.test.ts
+++ b/test/connect-origin.test.ts
@@ -13,8 +13,18 @@ import {
 } from "../src/transport/connect.js"
 import { createCursor } from "../src/index.js"
 import { resetClientVersionCache } from "../src/protocol/client-version.js"
+import { CursorProtocolError, CursorTransportError } from "../src/errors.js"
 
 const INSTALLER_FIXTURE = `var x="https://downloads.cursor.com/lab/2026.07.09-a3815c0/";`
+
+function pendingFetchUntilAbort(init?: RequestInit): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const signal = init?.signal
+    if (!signal) return reject(new Error("missing timeout signal"))
+    if (signal.aborted) return reject(signal.reason)
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+  })
+}
 
 describe("resolveAgentOrigin", () => {
   it("requires an explicit resolved agent host", () => {
@@ -92,6 +102,136 @@ describe("buildBaseHeaders", () => {
   it("uses the supplied client version", () => {
     const headers = buildBaseHeaders("token", "cli-test-123")
     expect(headers["x-cursor-client-version"]).toBe("cli-test-123")
+  })
+})
+
+describe("unary startup deadlines", () => {
+  it("times out a stalled AvailableModels fetch with a sanitized typed error", async () => {
+    const realFetch = globalThis.fetch
+    resetClientVersionCache()
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      return pendingFetchUntilAbort(init)
+    }) as typeof fetch
+    try {
+      const error = await unaryAvailableModels("secret-token", { timeoutMs: 10 })
+        .then(() => undefined, (cause) => cause)
+      expect(error).toBeInstanceOf(CursorTransportError)
+      expect(error).toMatchObject({
+        code: "CURSOR_AVAILABLE_MODELS_TIMEOUT",
+        origin: "transport",
+        transient: true,
+        replaySafe: true,
+      })
+      expect(error.message).not.toContain("secret-token")
+    } finally {
+      globalThis.fetch = realFetch
+      resetClientVersionCache()
+    }
+  })
+
+  it("times out stalled AvailableModels and GetServerConfig JSON body reads", async () => {
+    const realFetch = globalThis.fetch
+    resetClientVersionCache()
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input).includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      const response = Response.json({})
+      Object.defineProperty(response, "json", {
+        value: () => new Promise<never>(() => {}),
+      })
+      return response
+    }) as typeof fetch
+    try {
+      const availableModelsError = await unaryAvailableModels("secret-token", { timeoutMs: 10 })
+        .then(() => undefined, (cause) => cause)
+      const agentUrlError = await fetchAgentUrl("secret-token", { timeoutMs: 10 })
+        .then(() => undefined, (cause) => cause)
+      expect(availableModelsError).toMatchObject({ code: "CURSOR_AVAILABLE_MODELS_TIMEOUT" })
+      expect(agentUrlError).toMatchObject({
+        code: "CURSOR_AGENT_URL_TIMEOUT",
+        origin: "transport",
+        transient: true,
+        replaySafe: true,
+      })
+      expect(availableModelsError.message).not.toContain("secret-token")
+      expect(agentUrlError.message).not.toContain("secret-token")
+    } finally {
+      globalThis.fetch = realFetch
+      resetClientVersionCache()
+    }
+  })
+
+  it("times out a stalled GetServerConfig fetch", async () => {
+    const realFetch = globalThis.fetch
+    resetClientVersionCache()
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      return pendingFetchUntilAbort(init)
+    }) as typeof fetch
+    try {
+      const error = await fetchAgentUrl("secret-token", { timeoutMs: 10 })
+        .then(() => undefined, (cause) => cause)
+      expect(error).toBeInstanceOf(CursorTransportError)
+      expect(error).toMatchObject({ code: "CURSOR_AGENT_URL_TIMEOUT" })
+      expect(error.message).not.toContain("secret-token")
+    } finally {
+      globalThis.fetch = realFetch
+      resetClientVersionCache()
+    }
+  })
+
+  it("times out unary error-body reads that ignore abort", async () => {
+    const realFetch = globalThis.fetch
+    resetClientVersionCache()
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input).includes("cursor.com/install")) {
+        return new Response(INSTALLER_FIXTURE, { status: 200 })
+      }
+      const response = new Response("", { status: 503 })
+      Object.defineProperty(response, "text", {
+        value: () => new Promise<never>(() => {}),
+      })
+      return response
+    }) as typeof fetch
+    try {
+      const availableModelsError = await unaryAvailableModels("secret-token", { timeoutMs: 10 })
+        .then(() => undefined, (cause) => cause)
+      const agentUrlError = await fetchAgentUrl("secret-token", { timeoutMs: 10 })
+        .then(() => undefined, (cause) => cause)
+      expect(availableModelsError).toMatchObject({ code: "CURSOR_AVAILABLE_MODELS_TIMEOUT" })
+      expect(agentUrlError).toMatchObject({ code: "CURSOR_AGENT_URL_TIMEOUT" })
+    } finally {
+      globalThis.fetch = realFetch
+      resetClientVersionCache()
+    }
+  })
+
+  it("rejects invalid unary timeout values before fetching", async () => {
+    const realFetch = globalThis.fetch
+    let calls = 0
+    globalThis.fetch = (async () => {
+      calls += 1
+      throw new Error("unexpected fetch")
+    }) as typeof fetch
+    try {
+      for (const request of [
+        unaryAvailableModels("secret-token", { timeoutMs: 0 }),
+        fetchAgentUrl("secret-token", { timeoutMs: Number.NaN }),
+      ]) {
+        const error = await request.then(() => undefined, (cause) => cause)
+        expect(error).toBeInstanceOf(CursorProtocolError)
+        expect(error).toMatchObject({ code: "CURSOR_INVALID_TIMEOUT" })
+      }
+      expect(calls).toBe(0)
+    } finally {
+      globalThis.fetch = realFetch
+    }
   })
 })
 

--- a/test/display-bridge-pump.test.ts
+++ b/test/display-bridge-pump.test.ts
@@ -4,6 +4,7 @@ import { decodeMessage, encodeMessage } from "../src/protocol/messages.js"
 import { toolsToDescriptors, toolsToMcpDescriptors } from "../src/protocol/tools.js"
 import { pump } from "../src/language-model.js"
 import { sessionManager, type CursorSession, type Frame } from "../src/session.js"
+import { CursorProtocolError } from "../src/errors.js"
 
 function writeVarint(out: number[], value: number): void {
   let remaining = value >>> 0
@@ -498,43 +499,41 @@ describe("display-only ToolCall pump bridge", () => {
   it("fails promptly for an unknown exec variant instead of guessing a response", async () => {
     const writes: Uint8Array[] = []
     const parts: any[] = []
-    let streamError: Error | undefined
     const session = fakeSession([rawExecPayload(42, 38)], writes)
     const controller = {
       enqueue(part: unknown) {
         parts.push(part)
       },
-      error(error: Error) {
-        streamError = error
-      },
+      error() {},
     } as ReadableStreamDefaultController<any>
 
-    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
-
-    expect(streamError?.message).toContain(
-      "Unsupported Cursor exec variant smart_mode_classifier_args " +
-      "(request field #38, expected result smart_mode_classifier_result field #38, handling=unsupported)",
-    )
+    await expect(
+      pump(session, controller, { textId: "text", reasoningId: "reasoning" }),
+    ).rejects.toMatchObject({
+      message:
+        "Unsupported Cursor exec variant smart_mode_classifier_args " +
+        "(request field #38, expected result smart_mode_classifier_result field #38, handling=unsupported) (id=42)",
+      code: "CURSOR_RUN_REQUEST_UNSUPPORTED",
+    })
     expect(writes).toHaveLength(0)
     expect(parts.some((p) => p.type === "finish")).toBe(false)
+    expect(session.closed).toBe(true)
   })
 
   it("distinguishes future protocol drift from a known unsupported exec", async () => {
     const writes: Uint8Array[] = []
-    let streamError: Error | undefined
     const session = fakeSession([rawExecPayload(42, 53)], writes)
     const controller = {
       enqueue() {},
-      error(error: Error) {
-        streamError = error
-      },
+      error() {},
     } as ReadableStreamDefaultController<any>
 
-    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
-
-    expect(streamError?.message).toContain(
-      "Unsupported Cursor exec variant unknown request field #53 (id=42)",
-    )
+    await expect(
+      pump(session, controller, { textId: "text", reasoningId: "reasoning" }),
+    ).rejects.toMatchObject({
+      message: "Unsupported Cursor exec variant unknown request field #53 (id=42)",
+      code: "CURSOR_RUN_REQUEST_UNSUPPORTED",
+    })
     expect(writes).toHaveLength(0)
   })
 
@@ -775,7 +774,6 @@ describe("display-only ToolCall pump bridge", () => {
 
   it("fails closed when request_context write throws (F5)", async () => {
     const parts: any[] = []
-    let streamError: Error | undefined
     const session = fakeSession(
       [
         encodeMessage("AgentServerMessage", {
@@ -795,20 +793,21 @@ describe("display-only ToolCall pump bridge", () => {
       enqueue(part: unknown) {
         parts.push(part)
       },
-      error(error: Error) {
-        streamError = error
-      },
+      error() {},
     } as ReadableStreamDefaultController<any>
 
-    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+    await expect(
+      pump(session, controller, { textId: "text", reasoningId: "reasoning" }),
+    ).rejects.toEqual(expect.objectContaining<Partial<CursorProtocolError>>({
+      message: "Cursor request-context reply failed",
+      code: "CURSOR_RUN_REPLY_FAILED",
+    }))
 
-    expect(streamError?.message).toContain("request_context")
     expect(session.closed).toBe(true)
     expect(parts.some((part) => part.type === "tool-call")).toBe(false)
   })
 
   it("fails closed when a KV reply write throws (F5)", async () => {
-    let streamError: Error | undefined
     const session = fakeSession(
       [
         encodeMessage("AgentServerMessage", {
@@ -826,14 +825,16 @@ describe("display-only ToolCall pump bridge", () => {
     }
     const controller = {
       enqueue() {},
-      error(error: Error) {
-        streamError = error
-      },
+      error() {},
     } as unknown as ReadableStreamDefaultController<any>
 
-    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+    await expect(
+      pump(session, controller, { textId: "text", reasoningId: "reasoning" }),
+    ).rejects.toEqual(expect.objectContaining<Partial<CursorProtocolError>>({
+      message: "Cursor KV reply failed",
+      code: "CURSOR_RUN_REPLY_FAILED",
+    }))
 
-    expect(streamError?.message).toContain("KV blob request")
     expect(session.closed).toBe(true)
   })
 })

--- a/test/interactions.test.ts
+++ b/test/interactions.test.ts
@@ -234,19 +234,22 @@ describe("interaction query pump regression", () => {
 
   it("errors and closes promptly for an unknown variant", async () => {
     const writes: Uint8Array[] = []
-    let streamError: Error | undefined
     let destroyed = false
     const session = fakeSession([unknownQueryPayload(91, 99)], writes)
     session.stream.destroy = () => { destroyed = true }
     const controller = {
       enqueue() {},
-      error(error: Error) { streamError = error },
+      error() {},
     } as unknown as ReadableStreamDefaultController<any>
 
-    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+    await expect(
+      pump(session, controller, { textId: "text", reasoningId: "reasoning" }),
+    ).rejects.toMatchObject({
+      name: "CursorProtocolError",
+      code: "CURSOR_RUN_REQUEST_UNSUPPORTED",
+    })
 
     expect(writes).toHaveLength(0)
-    expect(streamError).toBeInstanceOf(UnsupportedInteractionQueryError)
     expect(destroyed).toBe(true)
   })
 })

--- a/test/run-interruption.test.ts
+++ b/test/run-interruption.test.ts
@@ -5,18 +5,18 @@ import {
   pump,
   pumpWithRecovery,
 } from "../src/language-model.js"
-import { encodeMessage } from "../src/protocol/messages.js"
+import { decodeMessage, encodeMessage } from "../src/protocol/messages.js"
 import type { CursorSession, Frame } from "../src/session.js"
 import { CursorRunInterruptedError } from "../src/transport/connect.js"
 import { CursorRetryExhaustedError } from "../src/errors.js"
 
-function fakeSession(id: string, frames: Frame[]): CursorSession {
+function fakeSession(id: string, frames: Frame[], writes: Uint8Array[] = []): CursorSession {
   let index = 0
   return {
     sessionId: id,
     conversationId: `conv-${id}`,
     stream: {
-      write() {},
+      write(data: Uint8Array) { writes.push(data) },
       end() {},
       frames: () => ({
         async *[Symbol.asyncIterator]() {
@@ -58,6 +58,37 @@ function serverFrame(message: Record<string, unknown>, flags = 0): Frame {
     flags,
     payload: encodeMessage("AgentServerMessage", message),
   }
+}
+
+function writeVarint(out: number[], value: number): void {
+  let remaining = value >>> 0
+  while (remaining > 0x7f) {
+    out.push((remaining & 0x7f) | 0x80)
+    remaining >>>= 7
+  }
+  out.push(remaining)
+}
+
+function lengthDelimitedField(field: number, bytes = new Uint8Array()): Uint8Array {
+  const out: number[] = []
+  writeVarint(out, (field << 3) | 2)
+  writeVarint(out, bytes.length)
+  out.push(...bytes)
+  return Uint8Array.from(out)
+}
+
+function varintField(field: number, value: number): Uint8Array {
+  const out: number[] = []
+  writeVarint(out, (field << 3) | 0)
+  writeVarint(out, value)
+  return Uint8Array.from(out)
+}
+
+function fixed32Field(field: number, value = 0): Uint8Array {
+  const out: number[] = []
+  writeVarint(out, (field << 3) | 5)
+  out.push(value & 0xff, 0, 0, 0)
+  return Uint8Array.from(out)
 }
 
 describe("interrupted Cursor Run handling", () => {
@@ -102,6 +133,53 @@ describe("interrupted Cursor Run handling", () => {
     expect(seen).toEqual(["first", "second"])
     expect(parts.some((part) => part.type === "text-delta" && part.delta === "continued")).toBe(true)
     expect(parts.filter((part) => part.type === "finish")).toHaveLength(1)
+  })
+
+  it("recovers after idempotent checkpoint and control-plane activity", async () => {
+    const writes: Uint8Array[] = []
+    const interrupted = fakeSession("control-frames", [
+      serverFrame({ conversation_checkpoint_update: Uint8Array.from([1, 2, 3]) }),
+      serverFrame({ exec_server_message: { id: 1, request_context_args: {} } }),
+      serverFrame({
+        exec_server_message: {
+          id: 2,
+          mcp_state_exec_args: { server_identifiers: ["opencode"] },
+        },
+      }),
+      serverFrame({
+        kv_server_message: {
+          id: 3,
+          set_blob_args: {
+            blob_id: Uint8Array.from([4, 5, 6]),
+            blob_data: Uint8Array.from([7, 8, 9]),
+          },
+        },
+      }),
+      serverFrame({
+        interaction_query: {
+          id: 4,
+          web_search_request_query: new Uint8Array(),
+        },
+      }),
+    ], writes)
+    const recovered = fakeSession("control-recovery", [
+      serverFrame({ interaction_update: { turn_ended: { input_tokens: 2, output_tokens: 1 } } }),
+    ])
+    let recoveries = 0
+
+    const finalSession = await pumpWithRecovery({
+      initialSession: interrupted,
+      controller: controller([]),
+      retryPolicy: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+      recover: async () => {
+        recoveries++
+        return recovered
+      },
+    })
+
+    expect(finalSession).toBe(recovered)
+    expect(recoveries).toBe(1)
+    expect(writes).toHaveLength(4)
   })
 
   it("surfaces a second interruption instead of retrying forever", async () => {
@@ -153,6 +231,113 @@ describe("interrupted Cursor Run handling", () => {
     ).rejects.toThrow("automatic retry unsafe")
     expect(recoveries).toBe(0)
     expect(parts.some((part) => part.type === "text-delta" && part.delta === "partial")).toBe(true)
+  })
+
+  it("replies to decoded KV requests with unknown fields, then suppresses replay", async () => {
+    const writes: Uint8Array[] = []
+    const getBlob = lengthDelimitedField(1, new TextEncoder().encode("inline blob"))
+    const getWithUnknownField = Uint8Array.from([
+      ...varintField(1, 15),
+      ...lengthDelimitedField(2, getBlob),
+      ...fixed32Field(20),
+    ])
+    const setBlob = Uint8Array.from([
+      ...lengthDelimitedField(1, new TextEncoder().encode("stored blob")),
+      ...lengthDelimitedField(2, new TextEncoder().encode("stored data")),
+    ])
+    const setWithUnknownField = Uint8Array.from([
+      ...varintField(1, 16),
+      ...lengthDelimitedField(3, setBlob),
+      ...fixed32Field(20),
+    ])
+    let recoveries = 0
+
+    await expect(
+      pumpWithRecovery({
+        initialSession: fakeSession("kv-unknown-field", [
+          { flags: 0, payload: lengthDelimitedField(4, getWithUnknownField) },
+          { flags: 0, payload: lengthDelimitedField(4, setWithUnknownField) },
+        ], writes),
+        controller: controller([]),
+        retryPolicy: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+        recover: async () => {
+          recoveries++
+          return fakeSession("unused", [])
+        },
+      }),
+    ).rejects.toThrow("automatic retry unsafe")
+
+    expect(recoveries).toBe(0)
+    expect(writes).toHaveLength(2)
+    const getReply = decodeMessage<any>("AgentClientMessage", writes[0]!).kv_client_message
+    expect(getReply.id).toBe(15)
+    expect(getReply.get_blob_result.blob_data).toEqual(new TextEncoder().encode("inline blob"))
+    const setReply = decodeMessage<any>("AgentClientMessage", writes[1]!).kv_client_message
+    expect(setReply.id).toBe(16)
+    expect(setReply.set_blob_result).toBeDefined()
+  })
+
+  it("answers decoded request-context and MCP probes despite unknown fields", async () => {
+    for (const [name, variantField, resultField] of [
+      ["request-context", 10, "request_context_result"],
+      ["mcp-state", 36, "mcp_state_exec_result"],
+    ] as const) {
+      const writes: Uint8Array[] = []
+      const execWithUnknownField = Uint8Array.from([
+        ...varintField(1, 16),
+        ...lengthDelimitedField(variantField),
+        ...fixed32Field(60),
+      ])
+      let recoveries = 0
+      await expect(
+        pumpWithRecovery({
+          initialSession: fakeSession(name, [
+            { flags: 0, payload: lengthDelimitedField(2, execWithUnknownField) },
+          ], writes),
+          controller: controller([]),
+          retryPolicy: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+          recover: async () => {
+            recoveries++
+            return fakeSession("unused", [])
+          },
+        }),
+      ).rejects.toThrow("automatic retry unsafe")
+
+      expect(writes).toHaveLength(1)
+      expect(recoveries).toBe(0)
+      const reply = decodeMessage<any>("AgentClientMessage", writes[0]!).exec_client_message
+      expect(reply.id).toBe(16)
+      expect(reply[resultField].success).toBeDefined()
+    }
+  })
+
+  it("fails immediately for undecodable or unhandled must-reply frames", async () => {
+    const cases: Array<[string, Frame, string]> = [
+      [
+        "undecodable-kv",
+        { flags: 0, payload: Uint8Array.from([0x22, 0x05, 0x08]) },
+        "CURSOR_RUN_REQUEST_DECODE_FAILED",
+      ],
+      [
+        "unhandled-kv",
+        { flags: 0, payload: lengthDelimitedField(4, varintField(1, 17)) },
+        "CURSOR_RUN_REQUEST_UNSUPPORTED",
+      ],
+    ]
+
+    for (const [id, frame, code] of cases) {
+      const session = fakeSession(id, [frame])
+      await expect(
+        pump(session, controller([]), { textId: "t", reasoningId: "r" }),
+      ).rejects.toMatchObject({
+        name: "CursorProtocolError",
+        origin: "protocol",
+        transient: false,
+        replaySafe: false,
+        code,
+      })
+      expect(session.closed).toBe(true)
+    }
   })
 
   it("resumes the latest checkpoint after visible output instead of replaying the turn", async () => {

--- a/test/struct.test.ts
+++ b/test/struct.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { encodeJsonAsValue, decodeValueToJson } from "../src/protocol/struct.js"
+import { encodeJsonAsValue, decodeValueToJson, readAllFieldsStrict } from "../src/protocol/struct.js"
 
 // Minimal google.protobuf.Value decoder for verification.
 function readVarint(b: Uint8Array, i: number): [number, number] {
@@ -111,5 +111,37 @@ describe("decodeValueToJson (production decoder)", () => {
     expect(decodeValueToJson(encodeJsonAsValue(3.5))).toBe(3.5)
     expect(decodeValueToJson(encodeJsonAsValue(false))).toBe(false)
     expect(decodeValueToJson(encodeJsonAsValue(null))).toBe(null)
+  })
+})
+
+describe("readAllFieldsStrict", () => {
+  it("represents every supported wire type", () => {
+    const decoded = readAllFieldsStrict(Uint8Array.from([
+      0x08, 0x01,
+      0x12, 0x01, 0x61,
+      0x1d, 0x01, 0x02, 0x03, 0x04,
+      0x21, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    ]))
+    expect(decoded?.map((field) => [field.fn, field.wt])).toEqual([
+      [1, 0], [2, 2], [3, 5], [4, 1],
+    ])
+  })
+
+  it("rejects truncated, unsupported, and overflowing wire encodings", () => {
+    expect(readAllFieldsStrict(Uint8Array.from([0x12, 0x02, 0x61]))).toBeUndefined()
+    expect(readAllFieldsStrict(Uint8Array.from([0x0b]))).toBeUndefined()
+    expect(readAllFieldsStrict(Uint8Array.from([0x84, 0x80, 0x80, 0x80, 0x10]))).toBeUndefined()
+    expect(readAllFieldsStrict(Uint8Array.from([
+      0x08,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02,
+    ]))).toBeUndefined()
+  })
+
+  it("preserves uint64 scalar values", () => {
+    const maximumUint64 = Uint8Array.from([
+      0x08,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+    ])
+    expect(readAllFieldsStrict(maximumUint64)?.[0]?.varint).toBe(0xffff_ffff_ffff_ffffn)
   })
 })


### PR DESCRIPTION
## What was going wrong?

In OpenCode, Cursor models sometimes looked like they were **thinking forever** and never answered.

There were **two separate bugs**:

### Bug 1: Startup could wait forever
When OpenCode asks Cursor things like:
- “what models do I have?”
- “which server should I talk to?”
- “please refresh my login token”

…the code waited for the network response **with no time limit**.

If Cursor’s servers accepted the request but never finished sending the body, OpenCode just sat there. No error. No answer. Just spinning.

### Bug 2: A normal Cursor “check-in” could stall the chat
Once a chat/run started, Cursor often sends small **control messages**, like:
- “give me request context”
- “what’s the MCP state?”
- “please store/read this tiny KV blob”

These are **not real tools**. They’re housekeeping. Cursor expects an immediate reply.

The old code treated almost every one of those messages as:
> “Something important happened. Do **not** safely retry/recover this run.”

So if the connection hiccuped after those check-ins, OpenCode could get stuck: it owed Cursor replies, recovery looked “unsafe,” and the turn hung until a long timeout (~5 minutes) finally failed.

## What this PR does

### 1. Add short timeouts to startup/login network calls
If those startup requests don’t finish in about **5 seconds**, fail with a clear error instead of spinning forever.

Important detail: we time out the **whole operation**, including reading the response body. Just canceling `fetch()` is not enough, because a stuck `json()` / `text()` read can ignore cancel.

### 2. Make run recovery smarter about “safe” vs “unsafe”
We did **not** invent retry/replay from scratch. OpenCode/Cursor recovery already existed.

This PR teaches the run loop:
- **Safe housekeeping** (`request_context`, `mcp_state`, normal KV get/set): answer them, and still allow recovery if needed
- **Real work** (visible text, real tool calls, messy/unknown must-reply frames): do **not** blindly replay

Also: if Cursor asks for a reply we truly cannot understand, **fail immediately** instead of hanging.

### 3. Tiny cleanup
Shared one small helper (`withAbortDeadline`) so connect/auth/version code use the same timeout race logic. No behavior change there.

## In one sentence
**Stop infinite waiting on startup calls, and stop treating Cursor’s normal housekeeping messages like dangerous side effects that block recovery.**

## How we tested

Automated:
- [x] `bun test` (553 passing)
- [x] typecheck
- [x] build

Live validation in OpenCode with the Cursor provider (all PASS):

| Probe | Model | Result |
|---|---|---|
| Text | `composer-2.5` | `CURSOR_TEXT_OK` |
| Stream | `composer-2.5` | `1..40` + `STREAM_OK` |
| Reasoning | `grok-4.5` high | `larger=37, smaller=15, GROK_HIGH_OK` |
| GPT High | `gpt-5.6-terra` high | `99242 TERRA_HIGH_OK` |
| 1M | `gpt-5.6-terra-1m` high | `TERRA_1M_OK` |
| Claude | `claude-opus-4-8` high | `no OPUS_OK` |
| Tool use | `composer-2.5` | README read → `TOOL_OK` |
| After cancel | session continue | `CURSOR_AFTER_CANCEL_OK` |
| Gemini | `gemini-3.5-flash` | `GEMINI_OK` |
| Sonnet | `claude-sonnet-5` high | `SONNET_OK` |
| Sol | `gpt-5.6-sol` high | `SOL_OK` |
| Multi-turn | `composer-2.5` | recalled codeword |
| Kimi | `kimi-k2.7-code` | `KIMI_OK` |
