### PR TITLE
fix: reject reads of non-existent paths before they reach OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenCode driving a Cursor-routed Grok model through this provider:
 - **Authentication** — browser OAuth (PKCE), or API key from [cursor.com/settings](https://cursor.com/settings)
 - **Model discovery** — fetches available models from Cursor's API and caches them locally
 - **Streaming** — bidirectional Connect-RPC Runs with stale-session rotation, health checks, semantic/read-idle deadlines, bounded replay-safe recovery, and activity-aware held tool continuations
-- **Tool calls** — maps Cursor exec-server messages to AI SDK / OpenCode tool-call parts, including native subagent/Task execution (Cursor's `generalPurpose` maps to OpenCode `general`; read-oriented `bugbot` reviews map to `explore`) and the Pi read/bash/edit/write/grep/find/ls request/result field range; enforces the exact current OpenCode agent catalog before emitting any tool call; mirrors finalized display-only todo/plan state into OpenCode; strips OpenCode's `read` XML envelope (`<path>`/`<content>` + `N:` prefixes) before returning content to Cursor so the model cannot echo the wrapper into writes
+- **Tool calls** — maps Cursor exec-server messages to AI SDK / OpenCode tool-call parts, including catalog-aware native subagent execution: exact advertised custom agents win, `unspecified` / `generalPurpose` select `general`, read-oriented `bugbot` / `security-review` select `explore`, and `cursor-guide` selects enabled Kilo `scout` before `explore`; MiMo `actor` is used instead of its work-item `task` tool when advertised. The bridge also covers the Pi read/bash/edit/write/grep/find/ls request/result range, enforces the exact current OpenCode tool catalog, mirrors finalized display-only todo/plan state, and strips OpenCode's `read` XML envelope before returning content to Cursor.
 - **Thinking / reasoning** — surfaces extended-thinking deltas where the model supports it
 
 ## Requirements
@@ -237,6 +237,18 @@ OpenCode
 The provider adds OpenCode-specific system guidance to normal tool-capable conversations, including tool availability, canonical workspace-path grounding, and preferring `edit` / `write` over shell-based file mutation when those tools are available. Compaction keeps its dedicated prompt unchanged.
 
 If this guidance causes issues, update `buildOpenCodeInteractionGuidance` in [`src/language-model.ts`](src/language-model.ts) and its focused coverage in [`test/prompt-history.test.ts`](test/prompt-history.test.ts).
+
+### Native subagent routing
+
+The provider reads the permission-filtered subagent catalog from the current host `task` or `actor` definition and advertises those recipients to Cursor as custom subagents. Exact configured names are preserved; unknown future Cursor subtype strings fall back to `general`. If a complete catalog omits every compatible recipient, the request fails on Cursor's typed subagent channel instead of selecting an arbitrary specialist.
+
+| Host | Default recipients | Optional recipients |
+|------|--------------------|---------------------|
+| OpenCode | `general`, `explore` | Add `agent/*.md` or `agents/*.md` with `mode: subagent` or `all` |
+| Kilo | `general`, `explore` | Enable `scout` with `KILO_EXPERIMENTAL_SCOUT=true` (or `KILO_EXPERIMENTAL=true`); add `.kilo/agent/*.md` custom agents with `mode: subagent` or `all` |
+| MiMo | `general`, `explore` | Add `.mimocode/agent/*.md` with `mode: subagent` |
+
+Kilo `scout` is reserved for external documentation, dependency repositories, and upstream source. Local workspace discovery continues to use `explore`. Primary modes and hidden/internal agents are never selected unless the host explicitly exposes them as spawnable.
 
 ## Package exports
 

--- a/src/context/agents.ts
+++ b/src/context/agents.ts
@@ -1,6 +1,6 @@
-import { readdir, readFile, stat } from "node:fs/promises"
+import { readdir, readFile, realpath, stat } from "node:fs/promises"
 import path from "node:path"
-import { opencodeGlobalConfigDir } from "./paths.js"
+import { opencodeGlobalConfigDirs, opencodeProjectConfigDirs } from "./paths.js"
 
 export type CollectedAgent = {
   fullPath: string
@@ -46,38 +46,101 @@ function parseAgentMarkdown(raw: string, fallbackName: string): {
   return { name, description, prompt: body.slice(0, 20_000) }
 }
 
-async function scanAgentDir(dir: string, out: Map<string, CollectedAgent>): Promise<void> {
-  if (!(await exists(dir))) return
-  let entries: string[]
-  try {
-    entries = await readdir(dir)
-  } catch {
-    return
-  }
-  for (const name of entries) {
-    if (!name.endsWith(".md")) continue
-    const full = path.join(dir, name)
-    try {
-      const raw = await readFile(full, "utf-8")
-      const parsed = parseAgentMarkdown(raw, name.replace(/\.md$/, ""))
-      if (!out.has(parsed.name)) {
-        out.set(parsed.name, {
-          fullPath: path.resolve(full),
-          name: parsed.name,
-          description: parsed.description,
-          prompt: parsed.prompt,
-        })
-      }
-    } catch {
-      /* skip */
-    }
-  }
+function uniquePaths(paths: string[]): string[] {
+  const seen = new Set<string>()
+  return paths.filter((value) => {
+    const normalized = path.resolve(value)
+    if (seen.has(normalized)) return false
+    seen.add(normalized)
+    return true
+  })
 }
 
-/** Custom OpenCode agents from `.opencode/agents` and global config. */
+/**
+ * Read one host config root's `agent/` and `agents/` trees. Host loaders use
+ * both spellings and recurse through nested markdown files. Directory symlinks
+ * are followed with realpath cycle detection, matching host behavior without
+ * allowing a symlink loop to hang context construction.
+ */
+async function scanAgentRoot(
+  root: string,
+  out: Map<string, CollectedAgent>,
+): Promise<void> {
+  if (!(await exists(root))) return
+  const visitedDirs = new Set<string>()
+  const scanDir = async (dir: string, relativePrefix: string): Promise<void> => {
+    let canonical: string
+    try {
+      canonical = await realpath(dir)
+    } catch {
+      return
+    }
+    if (visitedDirs.has(canonical)) return
+    visitedDirs.add(canonical)
+
+    let entries: Array<import("node:fs").Dirent>
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+      entries.sort((a, b) => a.name.localeCompare(b.name))
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name)
+      const relative = path.join(relativePrefix, entry.name)
+      let isDirectory = entry.isDirectory()
+      let isFile = entry.isFile()
+      if (entry.isSymbolicLink()) {
+        try {
+          const target = await stat(full)
+          isDirectory = target.isDirectory()
+          isFile = target.isFile()
+        } catch {
+          continue
+        }
+      }
+      if (isDirectory) {
+        await scanDir(full, relative)
+        continue
+      }
+      if (!isFile || !entry.name.endsWith(".md")) continue
+
+      try {
+        const raw = await readFile(full, "utf-8")
+        const fallbackName = relative.replace(/\\/g, "/").replace(/\.md$/, "")
+        const parsed = parseAgentMarkdown(raw, fallbackName)
+        if (!out.has(parsed.name)) {
+          out.set(parsed.name, {
+            fullPath: path.resolve(full),
+            name: parsed.name,
+            description: parsed.description,
+            prompt: parsed.prompt,
+          })
+        }
+      } catch {
+        /* skip unreadable or malformed files without failing context build */
+      }
+    }
+  }
+
+  // Scan singular before plural, then let root ordering establish host
+  // precedence. This is deterministic and mirrors the hosts' brace glob.
+  await scanDir(path.join(root, "agent"), "agent")
+  await scanDir(path.join(root, "agents"), "agents")
+}
+
+/**
+ * Custom agents from the active OpenCode-compatible config roots. OCP may
+ * install a host-neutral bridge before loading this module; without one this
+ * remains the direct OpenCode discovery path.
+ */
 export async function collectAgents(workspaceRoot: string): Promise<CollectedAgent[]> {
   const out = new Map<string, CollectedAgent>()
-  await scanAgentDir(path.join(workspaceRoot, ".opencode", "agents"), out)
-  await scanAgentDir(path.join(opencodeGlobalConfigDir(), "agents"), out)
+  const roots = uniquePaths([
+    ...opencodeProjectConfigDirs(workspaceRoot),
+    ...opencodeGlobalConfigDirs(),
+  ])
+  for (const root of roots) await scanAgentRoot(root, out)
   return [...out.values()]
 }

--- a/src/context/build.ts
+++ b/src/context/build.ts
@@ -1,5 +1,11 @@
 import path from "node:path"
-import { toolsToDescriptors, toolsToMcpDescriptors, type OpencodeToolDef } from "../protocol/tools.js"
+import {
+  extractHostSubagentCatalog,
+  toolsToDescriptors,
+  toolsToMcpDescriptors,
+  type HostSubagentDefinition,
+  type OpencodeToolDef,
+} from "../protocol/tools.js"
 import { collectRules } from "./rules.js"
 import { collectSkills } from "./skills.js"
 import { collectAgents } from "./agents.js"
@@ -15,6 +21,17 @@ export type BuildRequestContextInput = {
   tools?: OpencodeToolDef[]
   providerIdentifier?: string
 }
+
+const DEFAULT_HOST_SUBAGENTS: HostSubagentDefinition[] = [
+  {
+    name: "general",
+    description: "General-purpose agent for complex research and multi-step tasks.",
+  },
+  {
+    name: "explore",
+    description: "Read-only agent for searching and understanding the local codebase.",
+  },
+]
 
 /**
  * Full RequestContext payload for live UMA + exec #10 reply.
@@ -41,6 +58,29 @@ export async function buildRequestContext(
   const flat = toolsToDescriptors(tools, providerIdentifier, mcpServerNames)
   const nested = toolsToMcpDescriptors(tools, providerIdentifier, mcpServerNames)
   const projectDir = ensureOpencodeProjectDir(workspaceRoot)
+  const hostSubagents = extractHostSubagentCatalog(tools)
+  const discoveredByName = new Map(agents.map((agent) => [agent.name, agent]))
+  const advertisedByName = new Map<string, HostSubagentDefinition>()
+  if (hostSubagents.executor) {
+    const source = hostSubagents.complete
+      ? hostSubagents.agents
+      : [...DEFAULT_HOST_SUBAGENTS, ...hostSubagents.agents, ...agents]
+    for (const agent of source) {
+      if (!advertisedByName.has(agent.name)) advertisedByName.set(agent.name, agent)
+    }
+  }
+  const customSubagents = [...advertisedByName.values()].map((agent) => {
+    const discovered = discoveredByName.get(agent.name)
+    return {
+      full_path: discovered?.fullPath ?? "",
+      name: agent.name,
+      description: discovered?.description || agent.description || "Host-configured subagent.",
+      // The host applies the real configured prompt when Task/Actor executes.
+      // Cursor only needs enough context to select the recipient intentionally.
+      prompt: discovered?.prompt ||
+        `Delegate to the host-configured ${agent.name} subagent; its host instructions and tools apply.`,
+    }
+  })
 
   const ctx: Record<string, unknown> = {
     env: buildEnv(workspaceRoot),
@@ -57,12 +97,7 @@ export async function buildRequestContext(
       content: s.content,
       description: s.description,
     })),
-    custom_subagents: agents.map((a) => ({
-      full_path: a.fullPath,
-      name: a.name,
-      description: a.description,
-      prompt: a.prompt,
-    })),
+    custom_subagents: customSubagents,
     mcp_file_system_options: {
       enabled: true,
       // Cursor metadata root (mcps / agent-tools), not the git workspace.
@@ -86,7 +121,7 @@ export async function buildRequestContext(
     git_repo_info_complete: true,
     git_status_info_complete: true,
     agent_skills_info_complete: true,
-    custom_subagents_info_complete: true,
+    custom_subagents_info_complete: hostSubagents.complete,
     mcp_file_system_info_complete: true,
     mcp_info_complete: true,
   }

--- a/src/context/build.ts
+++ b/src/context/build.ts
@@ -33,6 +33,37 @@ const DEFAULT_HOST_SUBAGENTS: HostSubagentDefinition[] = [
   },
 ]
 
+type AdvertisedSubagentCatalog = {
+  agents: HostSubagentDefinition[]
+  complete: boolean
+}
+
+/**
+ * Convert the raw host executor catalog into the exact subagent list advertised
+ * to Cursor. `hostSubagents.complete` answers a narrow question: did the host's
+ * task/actor tool itself expose an exhaustive recipient list (schema enum or
+ * catalog marker)? OpenCode's task tool intentionally uses a plain string, so
+ * that raw flag is false even though we can still advertise a complete Cursor
+ * catalog by adding built-in defaults and discovered agent files.
+ *
+ * `custom_subagents_info_complete` must describe the final advertised list, not
+ * the raw extraction source. If there is no executor, the empty list is
+ * complete. If the host catalog is complete, use it verbatim. Otherwise we make
+ * the advertised set complete by augmenting with default host agents and all
+ * locally discovered agents.
+ */
+function buildAdvertisedSubagentCatalog(
+  hostSubagents: ReturnType<typeof extractHostSubagentCatalog>,
+  discoveredAgents: HostSubagentDefinition[],
+): AdvertisedSubagentCatalog {
+  if (!hostSubagents.executor) return { agents: [], complete: true }
+  if (hostSubagents.complete) return { agents: hostSubagents.agents, complete: true }
+  return {
+    agents: [...DEFAULT_HOST_SUBAGENTS, ...hostSubagents.agents, ...discoveredAgents],
+    complete: true,
+  }
+}
+
 /**
  * Full RequestContext payload for live UMA + exec #10 reply.
  * Sourced from OpenCode discovery (and .claude/.agents skill fallbacks).
@@ -59,15 +90,11 @@ export async function buildRequestContext(
   const nested = toolsToMcpDescriptors(tools, providerIdentifier, mcpServerNames)
   const projectDir = ensureOpencodeProjectDir(workspaceRoot)
   const hostSubagents = extractHostSubagentCatalog(tools)
+  const advertisedSubagents = buildAdvertisedSubagentCatalog(hostSubagents, agents)
   const discoveredByName = new Map(agents.map((agent) => [agent.name, agent]))
   const advertisedByName = new Map<string, HostSubagentDefinition>()
-  if (hostSubagents.executor) {
-    const source = hostSubagents.complete
-      ? hostSubagents.agents
-      : [...DEFAULT_HOST_SUBAGENTS, ...hostSubagents.agents, ...agents]
-    for (const agent of source) {
-      if (!advertisedByName.has(agent.name)) advertisedByName.set(agent.name, agent)
-    }
+  for (const agent of advertisedSubagents.agents) {
+    if (!advertisedByName.has(agent.name)) advertisedByName.set(agent.name, agent)
   }
   const customSubagents = [...advertisedByName.values()].map((agent) => {
     const discovered = discoveredByName.get(agent.name)
@@ -121,7 +148,7 @@ export async function buildRequestContext(
     git_repo_info_complete: true,
     git_status_info_complete: true,
     agent_skills_info_complete: true,
-    custom_subagents_info_complete: hostSubagents.complete,
+    custom_subagents_info_complete: advertisedSubagents.complete,
     mcp_file_system_info_complete: true,
     mcp_info_complete: true,
   }

--- a/src/context/paths.ts
+++ b/src/context/paths.ts
@@ -7,6 +7,39 @@ import { trace } from "../debug.js"
 
 export type HostPathEnv = NodeJS.ProcessEnv
 
+/** Host-neutral bridge installed by OCP before an unchanged provider is loaded. */
+export const OPENCODE_PATH_BRIDGE = Symbol.for("opencode.compat.path-bridge")
+export type OpenCodePathBridge = {
+  projectConfigDirs: (workspaceRoot: string) => string[]
+  globalConfigDirs: () => string[]
+  configFileNames?: string[]
+}
+
+function pathBridge(): OpenCodePathBridge | undefined {
+  const value = (globalThis as Record<PropertyKey, unknown>)[OPENCODE_PATH_BRIDGE]
+  if (!value || typeof value !== "object") return undefined
+  const bridge = value as Partial<OpenCodePathBridge>
+  return typeof bridge.projectConfigDirs === "function" && typeof bridge.globalConfigDirs === "function"
+    ? bridge as OpenCodePathBridge
+    : undefined
+}
+
+export function opencodeProjectConfigDirs(workspaceRoot: string): string[] {
+  return pathBridge()?.projectConfigDirs(path.resolve(workspaceRoot)) ?? [
+    path.join(path.resolve(workspaceRoot), ".opencode"),
+  ]
+}
+
+export function opencodeGlobalConfigDirs(): string[] {
+  return pathBridge()?.globalConfigDirs() ?? [opencodeGlobalConfigDir()]
+}
+
+export function opencodeConfigFileNames(): string[] {
+  return pathBridge()?.configFileNames?.length
+    ? [...pathBridge()!.configFileNames!]
+    : ["opencode.json", "opencode.jsonc"]
+}
+
 type CompatDetectResult = {
   id: string
   supported: boolean

--- a/src/context/plugins.ts
+++ b/src/context/plugins.ts
@@ -1,6 +1,6 @@
 import { readdir, stat } from "node:fs/promises"
 import path from "node:path"
-import { opencodeGlobalConfigDir } from "./paths.js"
+import { opencodeGlobalConfigDirs, opencodeProjectConfigDirs } from "./paths.js"
 import type { OpencodeJson } from "./rules.js"
 
 export type CollectedPlugin = {
@@ -42,15 +42,19 @@ export async function collectPlugins(
     seen.add(id)
     out.push({ id, source: "npm" })
   }
-  for (const p of await listLocalPlugins(path.join(workspaceRoot, ".opencode", "plugins"))) {
-    if (seen.has(p.id)) continue
-    seen.add(p.id)
-    out.push(p)
+  for (const configDir of opencodeProjectConfigDirs(workspaceRoot)) {
+    for (const p of await listLocalPlugins(path.join(configDir, "plugins"))) {
+      if (seen.has(p.id)) continue
+      seen.add(p.id)
+      out.push(p)
+    }
   }
-  for (const p of await listLocalPlugins(path.join(opencodeGlobalConfigDir(), "plugins"))) {
-    if (seen.has(p.id)) continue
-    seen.add(p.id)
-    out.push(p)
+  for (const configDir of opencodeGlobalConfigDirs()) {
+    for (const p of await listLocalPlugins(path.join(configDir, "plugins"))) {
+      if (seen.has(p.id)) continue
+      seen.add(p.id)
+      out.push(p)
+    }
   }
   return out
 }

--- a/src/context/rules.ts
+++ b/src/context/rules.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
-import { opencodeGlobalConfigDir, resolveHomeRelative } from "./paths.js"
+import { opencodeConfigFileNames, opencodeGlobalConfigDirs, opencodeProjectConfigDirs, resolveHomeRelative } from "./paths.js"
 
 export type CollectedRule = {
   fullPath: string
@@ -26,7 +26,7 @@ async function exists(file: string): Promise<boolean> {
 }
 
 async function readJsonConfig(dir: string): Promise<OpencodeJson> {
-  for (const name of ["opencode.json", "opencode.jsonc"]) {
+  for (const name of opencodeConfigFileNames()) {
     const file = path.join(dir, name)
     if (!(await exists(file))) continue
     try {
@@ -155,28 +155,30 @@ export async function fetchRemoteInstruction(
   }
 }
 
-export async function loadMergedConfig(workspaceRoot: string): Promise<OpencodeJson> {
-  const globalConfig = await readJsonConfig(opencodeGlobalConfigDir())
-  if (isProjectConfigDisabled()) {
-    return {
-      ...globalConfig,
-      instructions: [...(globalConfig.instructions ?? [])],
-      plugin: [...(globalConfig.plugin ?? [])],
-      plugins: [...(globalConfig.plugins ?? [])],
-      mcp: { ...(globalConfig.mcp ?? {}) },
-      permission: globalConfig.permission,
-    }
-  }
-  const projectConfig = await readJsonConfig(workspaceRoot)
+function mergeConfig(base: OpencodeJson, overlay: OpencodeJson): OpencodeJson {
   return {
-    ...globalConfig,
-    ...projectConfig,
-    instructions: [...(globalConfig.instructions ?? []), ...(projectConfig.instructions ?? [])],
-    plugin: [...new Set([...(globalConfig.plugin ?? []), ...(projectConfig.plugin ?? [])])],
-    plugins: [...new Set([...(globalConfig.plugins ?? []), ...(projectConfig.plugins ?? [])])],
-    mcp: { ...(globalConfig.mcp ?? {}), ...(projectConfig.mcp ?? {}) },
-    permission: projectConfig.permission ?? globalConfig.permission,
+    ...base,
+    ...overlay,
+    instructions: [...(base.instructions ?? []), ...(overlay.instructions ?? [])],
+    plugin: [...new Set([...(base.plugin ?? []), ...(overlay.plugin ?? [])])],
+    plugins: [...new Set([...(base.plugins ?? []), ...(overlay.plugins ?? [])])],
+    mcp: { ...(base.mcp ?? {}), ...(overlay.mcp ?? {}) },
+    permission: overlay.permission ?? base.permission,
   }
+}
+
+export async function loadMergedConfig(workspaceRoot: string): Promise<OpencodeJson> {
+  const globalConfig = await readJsonConfig(opencodeGlobalConfigDirs()[0] ?? "")
+  if (isProjectConfigDisabled()) return mergeConfig({}, globalConfig)
+
+  // The bridge supplies native project config roots for an unchanged plugin:
+  // .opencode on OpenCode, .mimocode on MiMo, and .kilo/.kilocode on Kilo.
+  // Later roots have higher precedence, matching the host's native ordering.
+  let projectConfig = await readJsonConfig(workspaceRoot)
+  for (const configDir of opencodeProjectConfigDirs(workspaceRoot)) {
+    projectConfig = mergeConfig(projectConfig, await readJsonConfig(configDir))
+  }
+  return mergeConfig(globalConfig, projectConfig)
 }
 
 /**
@@ -214,7 +216,9 @@ export async function collectRules(workspaceRoot: string): Promise<{
     }
   }
 
-  await add(path.join(opencodeGlobalConfigDir(), "AGENTS.md"))
+  for (const globalDir of opencodeGlobalConfigDirs()) {
+    await add(path.join(globalDir, "AGENTS.md"))
+  }
   await add(path.join(homedir(), ".claude", "CLAUDE.md"))
 
   for (const raw of config.instructions ?? []) {

--- a/src/context/skills.ts
+++ b/src/context/skills.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises"
 import path from "node:path"
 import { homedir } from "node:os"
-import { opencodeGlobalConfigDir } from "./paths.js"
+import { opencodeGlobalConfigDirs, opencodeProjectConfigDirs } from "./paths.js"
 
 export type CollectedSkill = {
   fullPath: string
@@ -94,8 +94,13 @@ export async function collectSkills(workspaceRoot: string, worktree: string): Pr
   const out = new Map<string, CollectedSkill>()
   const home = homedir()
 
-  await walkAncestorsFor(workspaceRoot, path.join(".opencode", "skills"), worktree, out)
-  await scanSkillsRoot(path.join(opencodeGlobalConfigDir(), "skills"), out)
+  for (const projectDir of opencodeProjectConfigDirs(workspaceRoot)) {
+    const relative = path.relative(workspaceRoot, projectDir)
+    await walkAncestorsFor(workspaceRoot, path.join(relative, "skills"), worktree, out)
+  }
+  for (const globalDir of opencodeGlobalConfigDirs()) {
+    await scanSkillsRoot(path.join(globalDir, "skills"), out)
+  }
 
   await walkAncestorsFor(workspaceRoot, path.join(".claude", "skills"), worktree, out)
   await scanSkillsRoot(path.join(home, ".claude", "skills"), out)

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -17,12 +17,17 @@ import {
   parseExecServerMessage,
   buildToolCallPart,
   buildExecClientMessages,
+  buildReadRejectionMessages,
+  classifyMissingReadTarget,
+  resolveReadTargetPath,
   parseExecIdFromToolCallId,
   detectExecVariantField,
   buildRequestContextResult,
   buildMcpStateResult,
   buildCustomWebToolAliases,
+  extractHostSubagentCatalog,
   resolveCustomWebToolAlias,
+  remapNativeSubagentForCatalog,
   CUSTOM_WEBFETCH_TOOL,
   CUSTOM_WEBSEARCH_TOOL,
   type OpencodeToolDef,
@@ -570,6 +575,7 @@ async function startSession(
     trace(`web tool alias: ${alias} -> ${original}`)
   }
   const allowTools = toolState.allowTools
+  const discoveredSubagentCatalog = extractHostSubagentCatalog(cursorTools)
   const resetState = resolveTurnConversationReset({ sessionKey, isCompaction })
   const recovery = startOptions?.recovery
   const resuming = recovery?.kind === "resume"
@@ -642,6 +648,25 @@ async function startSession(
     headers: options.headers,
   })
   const requestContext = await buildRequestContext({ workspaceRoot, tools: cursorTools })
+  const contextSubagents = Array.isArray(requestContext.custom_subagents)
+    ? requestContext.custom_subagents
+        .map((agent) => agent && typeof agent === "object" && typeof (agent as Record<string, unknown>).name === "string"
+          ? {
+              name: (agent as Record<string, unknown>).name as string,
+              description: typeof (agent as Record<string, unknown>).description === "string"
+                ? (agent as Record<string, unknown>).description as string
+                : undefined,
+            }
+          : undefined)
+        .filter((agent): agent is { name: string; description: string | undefined } => !!agent)
+    : []
+  const subagentCatalog = {
+    ...discoveredSubagentCatalog,
+    agents: [...new Map(
+      [...discoveredSubagentCatalog.agents, ...contextSubagents]
+        .map((agent) => [agent.name, agent]),
+    ).values()],
+  }
   // Resolve descriptors once from the merged OpenCode config so MCP identity is
   // consistent across AgentRunRequest and both request_context reply paths.
   const toolDescriptors = Array.isArray(requestContext.tools)
@@ -722,6 +747,7 @@ async function startSession(
     blobs: new Map(),
     toolDescriptors,
     toolAliases: webToolAliases.aliases,
+    subagentCatalog,
     requestContext,
     allowTools,
     usageEstimate,
@@ -1138,6 +1164,50 @@ export async function pump(
     }
   }
 
+  /**
+   * A read of a path that does not exist would otherwise reach OpenCode as a
+   * real tool call and raise a permission prompt for a file the user never had.
+   * Cursor's own LocalReadExecutor instead resolves the target against the
+   * workspace, stats it, and returns a typed ReadResult (file_not_found /
+   * invalid_file) before execution. Mirror that here: reply on the held-open
+   * exec channel with the exact typed case so the model receives a structured
+   * observation and the host surfaces no prompt.
+   *
+   * Read-only by construction — write/edit targets are never checked, so
+   * legitimate file creation (path resolves, file absent) is never denied. Runs
+   * after recoverMissingEditRead, which has already converted the new-file edit
+   * handshake read into an empty-file success. EACCES/EPERM and other stat
+   * errors fall through to OpenCode so a genuine permission decision stands.
+   */
+  const rejectMissingReadTarget = (parsed: ParsedExecRequest): boolean => {
+    if (parsed.toolName !== "read") return false
+    const requested = typeof parsed.args.filePath === "string" ? parsed.args.filePath : ""
+    if (!requested) return false
+    const workspaceRoot = workspaceRootFromRequestContext(session.requestContext)
+    const absolutePath = resolveReadTargetPath(requested, workspaceRoot)
+    const readResult = classifyMissingReadTarget(absolutePath)
+    if (!readResult) return false
+    try {
+      for (const frame of buildReadRejectionMessages(parsed.id, readResult)) {
+        session.stream.write(frame)
+      }
+      const kind = Object.keys(readResult)[0]
+      trace(
+        `exec: rejected missing read target id=${parsed.id} kind=${kind} ` +
+          `path=${JSON.stringify(absolutePath)}`,
+      )
+      return true
+    } catch (e) {
+      const error = new Error(
+        `Failed to reject Cursor read of a missing path: ${(e as Error).message}`,
+      )
+      trace(`exec: missing read rejection FAILED ${error.message}`)
+      safeError(error)
+      sessionManager.close(session)
+      return true
+    }
+  }
+
   /** AI SDK V3 requires text-end / reasoning-end before finish or tool-call. */
   const closeOpenSpans = () => {
     for (const part of spanEndParts({ textStarted, reasoningStarted, textId, reasoningId })) {
@@ -1501,6 +1571,7 @@ export async function pump(
             trace(`web tool alias resolved: ${parsed.toolName} -> ${executableToolName}`)
             parsed.toolName = executableToolName
           }
+          remapNativeSubagentForCatalog(parsed, advertisedToolNameSet, session.subagentCatalog)
         }
         const displayCallId = extractExecDisplayCallId(esm)
         trace(`exec: id=${parsed?.id} variant=${parsed ? Object.keys(parsed).join(",") : "none"} toolName=${parsed?.toolName} resultField=${parsed?.resultField}`)
@@ -1540,6 +1611,10 @@ export async function pump(
             continue
           }
           if (recoverMissingEditRead(parsed, displayCallId)) continue
+          if (rejectMissingReadTarget(parsed)) {
+            if (displayCallId) session.displayToolCalls.delete(displayCallId)
+            continue
+          }
           if (displayCallId) {
             session.displayToolCalls.delete(displayCallId)
             trace(`exec: claimed display callId=${displayCallId}`)
@@ -1766,6 +1841,7 @@ export function buildOpenCodeInteractionGuidance(
   const names = new Set(tools.map((tool) => tool.name))
   if (names.size === 0) return undefined
   const instructions: string[] = []
+  const subagents = extractHostSubagentCatalog(tools)
 
   if (names.has("question")) {
     instructions.push(
@@ -1794,6 +1870,21 @@ export function buildOpenCodeInteractionGuidance(
       `- To fetch a known URL, call \`${CUSTOM_WEBFETCH_TOOL}\`; do not use Cursor's native WebFetch interaction.`,
     )
   }
+  if (names.has("task") || names.has("actor")) {
+    const target = names.has("actor") ? "`actor`" : "`task`"
+    const available = subagents.agents.map((agent) => `\`${agent.name}\``).join(", ")
+    instructions.push(
+      `- Native Cursor Task/subagent requests are executed through OpenCode ${target}. ` +
+        "Advertised custom subagent names are used exactly; otherwise `unspecified` and `generalPurpose` select host `general`, " +
+        "`bugbot`, `security-review`, and `explore` select host `explore` (then `general`), and other specialized Cursor types fall back to `general`." +
+        (available ? ` Spawnable host agents this turn: ${available}.` : ""),
+    )
+    if (subagents.agents.some((agent) => agent.name === "scout")) {
+      instructions.push(
+        "- Host `scout` is available for external documentation and dependency-source research. Use Cursor `cursor-guide` for that use case; local repository discovery still uses `bugbot`/`explore`.",
+      )
+    }
+  }
   if (names.has("write")) {
     instructions.push(
       names.has("edit")
@@ -1804,7 +1895,9 @@ export function buildOpenCodeInteractionGuidance(
   return [
     `OpenCode exposes exactly these executable tools for this turn: ${[...names].map((name) => `\`${name}\``).join(", ")}.`,
     `Workspace root: ${JSON.stringify(workspaceRoot)}. Resolve workspace paths against exactly this root; never invent an absolute prefix, and verify uncertain paths with an available tool before using them.`,
-    "Call only tools in that exact list. Cursor-native tools that are not listed—including Task/subagents—are unavailable; do not invoke them. If a capability is absent, complete the work directly with the listed tools or explain the limitation.",
+    subagents.executor
+      ? "Call only tools in that exact list. Cursor-native Task/subagent requests are permitted because a compatible host executor is listed; other unlisted Cursor-native tools remain unavailable."
+      : "Call only tools in that exact list. Cursor-native tools that are not listed—including Task/subagents—are unavailable; do not invoke them. If a capability is absent, complete the work directly with the listed tools or explain the limitation.",
     ...(instructions.length > 0
       ? ["Use these OpenCode tools instead of equivalent Cursor-native UI interactions:"]
       : []),

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -426,14 +426,33 @@ export function createMessageTypes(): protobuf.Root {
     { id: 1, name: "path", type: "string" },
     { id: 2, name: "error", type: "string" },
   ])
+  // Cursor's LocalReadExecutor validates the target before execution and, for a
+  // missing / non-regular path, returns one of these typed ReadResult cases
+  // instead of running the tool. Mirroring the exact field ids/shapes lets this
+  // provider reply the same way so the model sees a structured file-not-found
+  // observation and the host never surfaces a permission prompt.
+  addType(root, "ReadFileNotFound", [{ id: 1, name: "path", type: "string" }])
+  addType(root, "ReadPermissionDenied", [{ id: 1, name: "path", type: "string" }])
+  addType(root, "ReadInvalidFile", [
+    { id: 1, name: "path", type: "string" },
+    { id: 2, name: "reason", type: "string" },
+  ])
   addType(
     root,
     "ReadResult",
     [
       { id: 1, name: "success", type: "ReadSuccess" },
       { id: 2, name: "error", type: "ReadError" },
+      { id: 4, name: "file_not_found", type: "ReadFileNotFound" },
+      { id: 5, name: "permission_denied", type: "ReadPermissionDenied" },
+      { id: 6, name: "invalid_file", type: "ReadInvalidFile" },
     ],
-    [{ name: "result", fields: ["success", "error"] }],
+    [
+      {
+        name: "result",
+        fields: ["success", "error", "file_not_found", "permission_denied", "invalid_file"],
+      },
+    ],
   )
 
   addType(root, "GrepArgs", [

--- a/src/protocol/tool-call-bridge.ts
+++ b/src/protocol/tool-call-bridge.ts
@@ -1,4 +1,4 @@
-import { mapCursorArgsToOpencode, mcpRealToolName } from "./tools.js"
+import { mapCursorArgsToOpencode, mapCursorSubagentTypeToOpenCode, mcpRealToolName } from "./tools.js"
 import { decodeStructEntriesToJson } from "./struct.js"
 
 /**
@@ -371,7 +371,17 @@ function openCodeSubagentType(raw: unknown): string | undefined {
   if (!subtype) return undefined
   const custom = asRecord(subtype.custom)
   if (typeof custom?.name === "string" && custom.name.length > 0) return custom.name
-  if (subtype.explore != null) return "explore"
+  if (subtype.explore != null) return mapCursorSubagentTypeToOpenCode("explore")
+  if (subtype.cursor_guide != null) return mapCursorSubagentTypeToOpenCode("cursor_guide")
+  if (subtype.bash != null) return mapCursorSubagentTypeToOpenCode("bash")
+  if (subtype.shell != null) return mapCursorSubagentTypeToOpenCode("shell")
+  if (subtype.debug != null) return mapCursorSubagentTypeToOpenCode("debug")
+  if (subtype.computer_use != null) return mapCursorSubagentTypeToOpenCode("computer_use")
+  if (subtype.browser_use != null) return mapCursorSubagentTypeToOpenCode("browser_use")
+  if (subtype.media_review != null) return mapCursorSubagentTypeToOpenCode("media_review")
+  if (subtype.watch_video != null) return mapCursorSubagentTypeToOpenCode("watch_video")
+  if (subtype.vm_setup_helper != null) return mapCursorSubagentTypeToOpenCode("vm_setup_helper")
+  if (subtype.unspecified != null) return mapCursorSubagentTypeToOpenCode("unspecified")
   return undefined
 }
 

--- a/src/protocol/tools.ts
+++ b/src/protocol/tools.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { encodeMessage } from "./messages.js"
 import { encodeJsonAsValue, decodeStructEntriesToJson, readAllFields } from "./struct.js"
 import { buildEnv } from "../context/env.js"
@@ -360,6 +362,228 @@ export function mapToolNameToExecField(toolName: string): string | undefined {
   return opencodeToolToCursor[toolName]
 }
 
+const CURSOR_SUBAGENT_TYPE_TO_OPENCODE: Record<string, string> = {
+  generalPurpose: "general",
+  "general-purpose": "general",
+  general_purpose: "general",
+  general: "general",
+  unspecified: "general",
+  "cursor-guide": "explore",
+  cursor_guide: "explore",
+  "best-of-n-runner": "general",
+  best_of_n_runner: "general",
+  bash: "general",
+  shell: "general",
+  debug: "general",
+  computer_use: "general",
+  computerUse: "general",
+  browser_use: "general",
+  browserUse: "general",
+  media_review: "general",
+  mediaReview: "general",
+  watch_video: "general",
+  watchVideo: "general",
+  vm_setup_helper: "general",
+  vmSetupHelper: "general",
+  explore: "explore",
+  bugbot: "explore",
+  "security-review": "explore",
+  security_review: "explore",
+}
+
+export type HostSubagentDefinition = {
+  name: string
+  description?: string
+}
+
+export type HostSubagentCatalog = {
+  executor?: "task" | "actor"
+  agents: HostSubagentDefinition[]
+  /** True when the host tool supplied its complete, permission-filtered catalog. */
+  complete: boolean
+}
+
+const SUBAGENT_CATALOG_MARKER = "Available agent types and the tools they have access to:"
+
+function parseSubagentDescriptionCatalog(description: string | undefined): {
+  found: boolean
+  agents: HostSubagentDefinition[]
+} {
+  if (!description) return { found: false, agents: [] }
+  const marker = description.indexOf(SUBAGENT_CATALOG_MARKER)
+  if (marker < 0) return { found: false, agents: [] }
+
+  const agents: HostSubagentDefinition[] = []
+  const lines = description.slice(marker + SUBAGENT_CATALOG_MARKER.length).split(/\r?\n/)
+  let started = false
+  for (const line of lines) {
+    const match = line.match(/^\s*-\s+([^:]+):\s*(.*)$/)
+    if (!match) {
+      if (started && line.trim()) break
+      continue
+    }
+    started = true
+    const name = match[1]!.trim().replace(/^`|`$/g, "")
+    if (!name) continue
+    const agentDescription = match[2]!.trim()
+    agents.push({
+      name,
+      ...(agentDescription ? { description: agentDescription } : {}),
+    })
+  }
+  return { found: true, agents }
+}
+
+function subagentTypeEnumValues(schema: unknown): string[] {
+  const out = new Set<string>()
+  const seen = new Set<object>()
+  const visit = (value: unknown, propertyName?: string): void => {
+    if (!value || typeof value !== "object") return
+    if (seen.has(value as object)) return
+    seen.add(value as object)
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, propertyName)
+      return
+    }
+
+    const record = value as Record<string, unknown>
+    if (propertyName === "subagent_type" && Array.isArray(record.enum)) {
+      for (const item of record.enum) {
+        if (typeof item === "string" && item) out.add(item)
+      }
+    }
+    for (const [key, child] of Object.entries(record)) visit(child, key)
+  }
+  visit(schema)
+  return [...out]
+}
+
+/** Extract the current host's permission-filtered Task/Actor recipient catalog. */
+export function extractHostSubagentCatalog(tools: OpencodeToolDef[]): HostSubagentCatalog {
+  const executorTool = tools.find((tool) => tool.name === "actor") ??
+    tools.find((tool) => tool.name === "task")
+  if (!executorTool) return { agents: [], complete: true }
+
+  const described = parseSubagentDescriptionCatalog(executorTool.description)
+  const enumNames = subagentTypeEnumValues(executorTool.inputSchema)
+  const descriptions = new Map(described.agents.map((agent) => [agent.name, agent.description]))
+  // MiMo's Actor enum is stricter than its prose catalog (`mode: subagent`
+  // rather than every non-primary agent), so structured names are authoritative.
+  const names = new Set(
+    enumNames.length > 0 ? enumNames : described.agents.map((agent) => agent.name),
+  )
+  return {
+    executor: executorTool.name as "task" | "actor",
+    agents: [...names].map((name) => ({
+      name,
+      ...(descriptions.get(name) ? { description: descriptions.get(name) } : {}),
+    })),
+    complete: enumNames.length > 0 || described.found,
+  }
+}
+
+const GENERIC_CURSOR_SUBAGENT_TYPES = new Set([
+  "generalPurpose",
+  "general-purpose",
+  "general_purpose",
+  "general",
+  "unspecified",
+])
+
+function cursorSubagentCandidates(subagentType: string): string[] {
+  if (GENERIC_CURSOR_SUBAGENT_TYPES.has(subagentType)) return ["general"]
+  if (subagentType === "cursor-guide" || subagentType === "cursor_guide") {
+    return ["scout", "explore", "general"]
+  }
+  if (
+    subagentType === "explore" ||
+    subagentType === "bugbot" ||
+    subagentType === "security-review" ||
+    subagentType === "security_review"
+  ) {
+    return ["explore", "general"]
+  }
+  return ["general"]
+}
+
+/** Resolve a Cursor subtype against the agents the host can spawn this turn. */
+export function resolveCursorSubagentType(
+  subagentType: string,
+  catalog?: HostSubagentCatalog,
+): string | undefined {
+  const available = new Set(catalog?.agents.map((agent) => agent.name) ?? [])
+
+  // Explicit host/custom names win. `unspecified` and general aliases are
+  // intentionally excluded so they always select the host's generic agent.
+  if (!GENERIC_CURSOR_SUBAGENT_TYPES.has(subagentType) && available.has(subagentType)) {
+    return subagentType
+  }
+
+  const candidates = cursorSubagentCandidates(subagentType)
+  for (const candidate of candidates) {
+    if (available.has(candidate)) return candidate
+  }
+  if (catalog?.complete) return undefined
+  return candidates[0]
+}
+
+/**
+ * Cursor's native Task/subagent protocol uses Cursor-owned subtype names while
+ * OpenCode-family hosts execute named agents. Map known Cursor built-ins to
+ * the closest host agent and preserve unknown values so user-defined OpenCode
+ * agents can still be called by exact name.
+ */
+export function mapCursorSubagentTypeToOpenCode(subagentType: string): string {
+  return CURSOR_SUBAGENT_TYPE_TO_OPENCODE[subagentType] ?? subagentType
+}
+
+/** Resolve a native Cursor subagent request to this turn's executor and catalog. */
+export function remapNativeSubagentForCatalog(
+  parsed: ParsedExecRequest,
+  advertisedToolNames: Iterable<string>,
+  catalog?: HostSubagentCatalog,
+): void {
+  if (parsed.resultField !== "subagent_result" || parsed.toolName !== "task") return
+  const advertised = new Set(advertisedToolNames)
+  const executor = advertised.has("actor") ? "actor" : advertised.has("task") ? "task" : undefined
+  if (!executor) return
+
+  const description = str(parsed.args.description) ?? ""
+  const prompt = str(parsed.args.prompt) ?? ""
+  const cursorSubagentType = str(parsed.resultMetadata?.cursor_subagent_type) ??
+    str(parsed.args.subagent_type) ?? ""
+  const subagentType = resolveCursorSubagentType(cursorSubagentType, catalog)
+  if (!subagentType) {
+    const available = catalog?.agents.map((agent) => agent.name).join(", ") || "none"
+    parsed.localError =
+      `Cursor subagent '${cursorSubagentType}' has no compatible host agent. ` +
+      `Available subagents: ${available}.`
+    return
+  }
+
+  const resumeAgentId = str(parsed.args.task_id)
+  parsed.toolName = executor
+  if (executor === "task") {
+    parsed.args = {
+      description,
+      prompt,
+      subagent_type: subagentType,
+      ...(resumeAgentId ? { task_id: resumeAgentId } : {}),
+      ...(parsed.args.background === true ? { background: true } : {}),
+    }
+    return
+  }
+  parsed.args = {
+    operation: {
+      action: parsed.args.background === true ? "spawn" : "run",
+      description,
+      prompt,
+      subagent_type: subagentType,
+      ...(resumeAgentId ? { actor_id: resumeAgentId } : {}),
+    },
+  }
+}
+
 // ── Extract exec args from ExecServerMessage ──
 
 export type ParsedExecRequest = {
@@ -453,6 +677,9 @@ export function parseExecServerMessage(
       toolName: "task",
       args,
       resultField,
+      resultMetadata: cursorSubagentType
+        ? { cursor_subagent_type: cursorSubagentType }
+        : undefined,
       localError:
         prompt && cursorSubagentType
           ? undefined
@@ -689,18 +916,6 @@ function describeSubagentTask(prompt?: string, subagentType?: string): string {
   return `${subagentType || "Delegated"} task`
 }
 
-function mapCursorSubagentTypeToOpenCode(subagentType: string): string {
-  // Cursor's built-in general agent uses a camelCase protocol identifier, and
-  // its native Bugbot reviewer has no OpenCode-specific agent definition.
-  // OpenCode `general` is the general-purpose equivalent; `explore` preserves
-  // Bugbot's review-only/read-oriented semantics while retaining grep/read/bash.
-  // Preserve every other value so `explore` and configured custom agents keep
-  // their exact advertised names.
-  if (subagentType === "generalPurpose") return "general"
-  if (subagentType === "bugbot") return "explore"
-  return subagentType
-}
-
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
 }
@@ -767,6 +982,84 @@ function findOneOfVariant(
     }
   }
   return undefined
+}
+
+// ── Pre-execution read validation (Cursor LocalReadExecutor parity) ──
+
+/** Expand a leading `~` to the home directory, matching Cursor's untildify. */
+function untildify(input: string): string {
+  return input.replace(/^~(?=$|\/|\\)/, os.homedir())
+}
+
+/**
+ * Resolve a read target the way Cursor's LocalReadExecutor does before it
+ * stats the file: untildify, then resolve a relative path against the workspace
+ * root (`env.workspace_paths[0]`), else resolve as-is. Kept in lockstep with
+ * agent utils `resolvePath(path, workspaceRoot)`.
+ */
+export function resolveReadTargetPath(requested: string, workspaceRoot: string): string {
+  const expanded = untildify(requested)
+  if (workspaceRoot && !path.isAbsolute(expanded)) {
+    return path.resolve(workspaceRoot, expanded)
+  }
+  return path.resolve(expanded)
+}
+
+/**
+ * A typed ReadResult oneof case for a read target that fails Cursor's
+ * pre-execution validation, or undefined when the path is a readable file the
+ * tool should actually read. Mirrors LocalReadExecutor exactly:
+ *  - missing path (ENOENT/ENOTDIR)     → file_not_found
+ *  - directory                         → invalid_file "Path is a directory, not a file"
+ *  - socket/fifo/etc (not a file)      → invalid_file "Path is neither a file nor a directory"
+ * EACCES/EPERM (exists but unreadable) and any other stat error return undefined
+ * so the call proceeds to OpenCode and a genuine permission decision is never
+ * masked. Never rejects a non-existent *write/edit* target — this is read-only.
+ */
+export function classifyMissingReadTarget(
+  absolutePath: string,
+): Record<string, unknown> | undefined {
+  let stat: fs.Stats
+  try {
+    stat = fs.statSync(absolutePath)
+  } catch (e) {
+    const code = (e as { code?: string }).code
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return { file_not_found: { path: absolutePath } }
+    }
+    return undefined
+  }
+  if (stat.isDirectory()) {
+    return { invalid_file: { path: absolutePath, reason: "Path is a directory, not a file" } }
+  }
+  if (!stat.isFile()) {
+    return {
+      invalid_file: { path: absolutePath, reason: "Path is neither a file nor a directory" },
+    }
+  }
+  return undefined
+}
+
+/**
+ * Encode a pre-execution read rejection as the exact frames Cursor's client
+ * emits: the ExecClientMessage carrying the typed ReadResult oneof case, then
+ * the ACM #5 stream_close for that id. `readResult` is the case object from
+ * classifyMissingReadTarget (e.g. `{ file_not_found: { path } }`).
+ */
+export function buildReadRejectionMessages(
+  execId: number,
+  readResult: Record<string, unknown>,
+): Uint8Array[] {
+  return [
+    encodeMessage("AgentClientMessage", {
+      exec_client_message: {
+        id: execId,
+        local_execution_time_ms: 0,
+        read_result: readResult,
+      },
+    }),
+    buildExecStreamClose(execId),
+  ]
 }
 
 // ── Build ExecClientMessage for a tool result ──

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,7 +2,7 @@ import type { BidiStream, BidiTerminalEvent } from "./transport/connect.js"
 import { trace } from "./debug.js"
 import { CursorProtocolError, type CursorProviderError } from "./errors.js"
 import { sessionActivity, type SessionActivitySource } from "./activity.js"
-import type { ToolAliasRegistry } from "./protocol/tools.js"
+import type { HostSubagentCatalog, ToolAliasRegistry } from "./protocol/tools.js"
 
 export type Frame = { flags: number; payload: Uint8Array }
 
@@ -188,6 +188,8 @@ export type CursorSession = {
   toolDescriptors: Array<Record<string, unknown>>
   /** Cursor-facing web alias → exact executable host tool for this Run. */
   toolAliases?: ToolAliasRegistry
+  /** Spawnable host agents extracted from this turn's Task/Actor definition. */
+  subagentCatalog?: HostSubagentCatalog
   /** Full RequestContext for exec #10 replies. */
   requestContext: Record<string, unknown>
   /**

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -56,6 +56,41 @@ describe("collectRules / buildRequestContext", () => {
     expect(skills.some((s) => s.name === "demo")).toBe(true)
   })
 
+  it("marks augmented custom subagents complete when the host exposes only string subagent_type", async () => {
+    const prevCache = process.env.XDG_CACHE_HOME
+    const cacheRoot = path.join(os.tmpdir(), `cursor-ctx-agents-string-${process.pid}-${Date.now()}`)
+    process.env.XDG_CACHE_HOME = cacheRoot
+    try {
+      const ctx = await buildRequestContext({
+        workspaceRoot: root,
+        tools: [{
+          name: "task",
+          description: "Launch a subagent with subagent_type.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              description: { type: "string" },
+              prompt: { type: "string" },
+              subagent_type: { type: "string" },
+            },
+          },
+        }],
+      })
+      const subagents = ctx.custom_subagents as Array<Record<string, unknown>>
+      expect(subagents.map((agent) => agent.name)).toEqual(["general", "explore", "reviewer"])
+      expect(String(subagents.find((agent) => agent.name === "reviewer")?.prompt).trim())
+        .toBe("Review carefully.")
+      // The raw host task schema is incomplete (subagent_type is a string, not an
+      // enum), but the provider augments it with defaults plus discovered agents.
+      // This flag describes the final advertised catalog, not the raw host parse.
+      expect(ctx.custom_subagents_info_complete).toBe(true)
+    } finally {
+      if (prevCache === undefined) delete process.env.XDG_CACHE_HOME
+      else process.env.XDG_CACHE_HOME = prevCache
+      await rm(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
   it("advertises the host's complete spawnable-agent catalog to Cursor", async () => {
     const prevCache = process.env.XDG_CACHE_HOME
     const cacheRoot = path.join(os.tmpdir(), `cursor-ctx-agents-${process.pid}-${Date.now()}`)

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -21,6 +21,11 @@ describe("collectRules / buildRequestContext", () => {
       path.join(root, ".opencode", "skills", "demo", "SKILL.md"),
       "---\nname: demo\ndescription: Demo skill\n---\n\nDo the demo.\n",
     )
+    await mkdir(path.join(root, ".opencode", "agents"), { recursive: true })
+    await writeFile(
+      path.join(root, ".opencode", "agents", "reviewer.md"),
+      "---\nname: reviewer\ndescription: Review local changes\n---\n\nReview carefully.\n",
+    )
     await mkdir(path.join(root, ".cursor", "rules"), { recursive: true })
     await writeFile(path.join(root, ".cursor", "rules", "extra.md"), "cursor instruction via opencode.json")
     await writeFile(
@@ -49,6 +54,47 @@ describe("collectRules / buildRequestContext", () => {
   it("discovers .opencode skills", async () => {
     const skills = await collectSkills(root, root)
     expect(skills.some((s) => s.name === "demo")).toBe(true)
+  })
+
+  it("advertises the host's complete spawnable-agent catalog to Cursor", async () => {
+    const prevCache = process.env.XDG_CACHE_HOME
+    const cacheRoot = path.join(os.tmpdir(), `cursor-ctx-agents-${process.pid}-${Date.now()}`)
+    process.env.XDG_CACHE_HOME = cacheRoot
+    try {
+      const ctx = await buildRequestContext({
+        workspaceRoot: root,
+        tools: [{
+          name: "task",
+          description: [
+            "Delegate work.",
+            "Available agent types and the tools they have access to:",
+            "- general: General-purpose work.",
+            "- explore: Local codebase search.",
+            "- scout: External dependency research.",
+            "- reviewer: Review local changes.",
+          ].join("\n"),
+        }],
+      })
+      const subagents = ctx.custom_subagents as Array<Record<string, unknown>>
+      expect(subagents.map((agent) => agent.name)).toEqual([
+        "general", "explore", "scout", "reviewer",
+      ])
+      expect(String(subagents.find((agent) => agent.name === "reviewer")?.prompt).trim())
+        .toBe("Review carefully.")
+      expect(subagents.find((agent) => agent.name === "scout")?.description)
+        .toBe("External dependency research.")
+      expect(ctx.custom_subagents_info_complete).toBe(true)
+
+      const decoded = decodeMessage<Record<string, unknown>>(
+        "RequestContext",
+        encodeMessage("RequestContext", ctx),
+      )
+      expect((decoded.custom_subagents as unknown[]).length).toBe(4)
+    } finally {
+      if (prevCache === undefined) delete process.env.XDG_CACHE_HOME
+      else process.env.XDG_CACHE_HOME = prevCache
+      await rm(cacheRoot, { recursive: true, force: true })
+    }
   })
 
   it("builds an encodable RequestContext with rules and skills", async () => {

--- a/test/display-bridge-pump.test.ts
+++ b/test/display-bridge-pump.test.ts
@@ -68,7 +68,7 @@ function rawExecPayload(
   return Uint8Array.from(asm)
 }
 
-function rawSubagentArgs(): Uint8Array {
+function rawSubagentArgs(subagentType = "generalPurpose"): Uint8Array {
   const out: number[] = []
   const text = new TextEncoder()
   const writeString = (field: number, value: string) => {
@@ -78,7 +78,7 @@ function rawSubagentArgs(): Uint8Array {
     out.push(...bytes)
   }
   writeString(1, "task-call-34")
-  writeString(2, "generalPurpose")
+  writeString(2, subagentType)
   writeString(4, "Investigate why the conversation stopped")
   return Uint8Array.from(out)
 }
@@ -279,6 +279,147 @@ describe("display-only ToolCall pump bridge", () => {
     expect(toolCall?.toolName).toBe("read")
     expect(JSON.parse(toolCall.input)).toEqual({ filePath: target })
     sessionManager.resolve(session.sessionId, 17)
+  })
+
+  it("rejects a read of a missing path with a typed file_not_found before OpenCode sees it", async () => {
+    const writes: Uint8Array[] = []
+    const parts: any[] = []
+    const target = `/tmp/cursor-opencode-hallucinated-${process.pid}-${Date.now()}.ts`
+    const session = fakeSession(
+      [
+        encodeMessage("AgentServerMessage", {
+          exec_server_message: { id: 21, read_args: { path: target } },
+        }),
+        turnEndedPayload(),
+      ],
+      writes,
+      [{ name: "read", description: "Read" }],
+    )
+    const controller = {
+      enqueue(part: unknown) {
+        parts.push(part)
+      },
+      error(error: Error) {
+        throw error
+      },
+    } as ReadableStreamDefaultController<any>
+
+    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+
+    // No host tool-call is emitted — the user never sees a permission prompt.
+    expect(parts.some((part) => part.type === "tool-call")).toBe(false)
+    expect(sessionManager.pendingFor(session.sessionId, 21)).toBeUndefined()
+    // The provider answers Cursor with the typed ReadResult.file_not_found case,
+    // then closes the exec stream, exactly as the CLI client does.
+    expect(writes).toHaveLength(2)
+    const result = decodeMessage<any>("AgentClientMessage", writes[0]!).exec_client_message
+    expect(result.id).toBe(21)
+    expect(result.read_result.file_not_found).toMatchObject({ path: target })
+    expect(result.read_result.success).toBeUndefined()
+    expect(result.read_result.error).toBeUndefined()
+    expect(decodeMessage<any>("AgentClientMessage", writes[1]!)).toEqual({
+      exec_client_control_message: { stream_close: { id: 21 } },
+    })
+  })
+
+  it("rejects a read of a directory with a typed invalid_file", async () => {
+    const writes: Uint8Array[] = []
+    const parts: any[] = []
+    const target = process.cwd() // a real directory, not a file
+    const session = fakeSession(
+      [
+        encodeMessage("AgentServerMessage", {
+          exec_server_message: { id: 22, read_args: { path: target } },
+        }),
+        turnEndedPayload(),
+      ],
+      writes,
+      [{ name: "read", description: "Read" }],
+    )
+    const controller = {
+      enqueue(part: unknown) {
+        parts.push(part)
+      },
+      error(error: Error) {
+        throw error
+      },
+    } as ReadableStreamDefaultController<any>
+
+    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+
+    expect(parts.some((part) => part.type === "tool-call")).toBe(false)
+    const result = decodeMessage<any>("AgentClientMessage", writes[0]!).exec_client_message
+    expect(result.read_result.invalid_file).toMatchObject({
+      path: target,
+      reason: "Path is a directory, not a file",
+    })
+  })
+
+  it("still emits a read tool-call for an existing file", async () => {
+    const writes: Uint8Array[] = []
+    const parts: any[] = []
+    const target = path.join(process.cwd(), "README.md")
+    const session = fakeSession(
+      [
+        encodeMessage("AgentServerMessage", {
+          exec_server_message: { id: 23, read_args: { path: target } },
+        }),
+      ],
+      writes,
+      [{ name: "read", description: "Read" }],
+    )
+    const controller = {
+      enqueue(part: unknown) {
+        parts.push(part)
+      },
+      error(error: Error) {
+        throw error
+      },
+    } as ReadableStreamDefaultController<any>
+
+    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+
+    expect(writes).toHaveLength(0)
+    const toolCall = parts.find((part) => part.type === "tool-call")
+    expect(toolCall?.toolName).toBe("read")
+    expect(JSON.parse(toolCall.input)).toEqual({ filePath: target })
+    sessionManager.resolve(session.sessionId, 23)
+  })
+
+  it("does not reject a write to a new file whose parent exists", async () => {
+    const writes: Uint8Array[] = []
+    const parts: any[] = []
+    const target = path.join(process.cwd(), `new-file-${process.pid}-${Date.now()}.txt`)
+    const session = fakeSession(
+      [
+        encodeMessage("AgentServerMessage", {
+          exec_server_message: {
+            id: 24,
+            write_args: { path: target, file_text: "hello\n" },
+          },
+        }),
+      ],
+      writes,
+      [{ name: "write", description: "Write" }],
+    )
+    const controller = {
+      enqueue(part: unknown) {
+        parts.push(part)
+      },
+      error(error: Error) {
+        throw error
+      },
+    } as ReadableStreamDefaultController<any>
+
+    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+
+    // File creation must never be denied — the write reaches OpenCode as a real
+    // tool-call even though the target does not exist yet.
+    expect(writes).toHaveLength(0)
+    const toolCall = parts.find((part) => part.type === "tool-call")
+    expect(toolCall?.toolName).toBe("write")
+    expect(JSON.parse(toolCall.input)).toEqual({ filePath: target, content: "hello\n" })
+    sessionManager.resolve(session.sessionId, 24)
   })
 
   it("does not replay a completed ask_question_tool_call", async () => {
@@ -564,6 +705,74 @@ describe("display-only ToolCall pump bridge", () => {
     expect(parts.some((part) =>
       part.type === "finish" && part.finishReason?.unified === "tool-calls"
     )).toBe(true)
+    expect(sessionManager.pendingFor(session.sessionId, 34)?.resultField).toBe("subagent_result")
+    sessionManager.resolve(session.sessionId, 34)
+  })
+
+  it("routes Cursor guide through enabled Kilo scout without changing local explore", async () => {
+    const writes: Uint8Array[] = []
+    const parts: any[] = []
+    const session = fakeSession(
+      [rawExecPayload(34, 28, rawSubagentArgs("cursor-guide"))],
+      writes,
+    )
+    session.subagentCatalog = {
+      executor: "task",
+      agents: [{ name: "general" }, { name: "explore" }, { name: "scout" }],
+      complete: true,
+    }
+    const controller = {
+      enqueue(part: unknown) {
+        parts.push(part)
+      },
+      error(error: Error) {
+        throw error
+      },
+    } as ReadableStreamDefaultController<any>
+
+    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+
+    const toolCall = parts.find((part) => part.type === "tool-call")
+    expect(toolCall?.toolName).toBe("task")
+    expect(JSON.parse(toolCall.input).subagent_type).toBe("scout")
+    sessionManager.resolve(session.sessionId, 34)
+  })
+
+  it("routes canonical subagent field #28 to MiMo actor when actor is advertised", async () => {
+    const writes: Uint8Array[] = []
+    const parts: any[] = []
+    let streamError: Error | undefined
+    const session = fakeSession(
+      [rawExecPayload(34, 28, rawSubagentArgs())],
+      writes,
+      [
+        { name: "actor", description: "Spawn actors" },
+        { name: "task", description: "Track work items" },
+        { name: "read", description: "Read" },
+      ],
+    )
+    const controller = {
+      enqueue(part: unknown) {
+        parts.push(part)
+      },
+      error(error: Error) {
+        streamError = error
+      },
+    } as ReadableStreamDefaultController<any>
+
+    await pump(session, controller, { textId: "text", reasoningId: "reasoning" })
+
+    expect(streamError).toBeUndefined()
+    const toolCall = parts.find((part) => part.type === "tool-call")
+    expect(toolCall?.toolName).toBe("actor")
+    expect(JSON.parse(toolCall.input)).toEqual({
+      operation: {
+        action: "run",
+        description: "Investigate why the conversation stopped",
+        prompt: "Investigate why the conversation stopped",
+        subagent_type: "general",
+      },
+    })
     expect(sessionManager.pendingFor(session.sessionId, 34)?.resultField).toBe("subagent_result")
     sessionManager.resolve(session.sessionId, 34)
   })

--- a/test/prompt-history.test.ts
+++ b/test/prompt-history.test.ts
@@ -83,6 +83,30 @@ describe("buildOpenCodeInteractionGuidance", () => {
     expect(guidance).toContain("`write` to create files")
     expect(guidance).toContain("do not use shell, Python, or heredocs")
   })
+
+  it("documents Cursor-native Task subtype mapping when subagents are advertised", () => {
+    const guidance = buildOpenCodeInteractionGuidance([
+      {
+        name: "actor",
+        inputSchema: {
+          properties: {
+            operation: {
+              properties: {
+                subagent_type: { enum: ["general", "explore", "scout"] },
+              },
+            },
+          },
+        },
+      },
+      { name: "task" },
+    ], false, "/workspace/project")
+
+    expect(guidance).toContain("Native Cursor Task/subagent requests are executed through OpenCode `actor`")
+    expect(guidance).toContain("`generalPurpose`")
+    expect(guidance).toContain("`bugbot`, `security-review`, and `explore` select host `explore`")
+    expect(guidance).toContain("Host `scout` is available")
+    expect(guidance).toContain("local repository discovery still uses `bugbot`/`explore`")
+  })
 })
 
 describe("extractPromptHistory", () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -22,6 +22,10 @@ import {
   unwrapReadOutput,
   buildCustomWebToolAliases,
   resolveCustomWebToolAlias,
+  extractHostSubagentCatalog,
+  mapCursorSubagentTypeToOpenCode,
+  remapNativeSubagentForCatalog,
+  resolveCursorSubagentType,
   REQUEST_CONTEXT_RESULT_FIELD,
 } from "../src/protocol/tools.js"
 import { decodeMessage, encodeMessage } from "../src/protocol/messages.js"
@@ -562,7 +566,13 @@ describe("parseExecServerMessage", () => {
     expect(result?.localError).toContain("missing a required prompt or subagent type")
   })
 
-  it("preserves compatible and custom OpenCode subagent names", () => {
+  it("maps known Cursor subagent types and preserves compatible custom OpenCode names", () => {
+    expect(mapCursorSubagentTypeToOpenCode("generalPurpose")).toBe("general")
+    expect(mapCursorSubagentTypeToOpenCode("cursor-guide")).toBe("explore")
+    expect(mapCursorSubagentTypeToOpenCode("best-of-n-runner")).toBe("general")
+    expect(mapCursorSubagentTypeToOpenCode("bugbot")).toBe("explore")
+    expect(mapCursorSubagentTypeToOpenCode("security-review")).toBe("explore")
+    expect(mapCursorSubagentTypeToOpenCode("computer_use")).toBe("general")
     for (const subagentType of ["explore", "my-reviewer"]) {
       const result = parseExecServerMessage({
         id: 34,
@@ -570,6 +580,83 @@ describe("parseExecServerMessage", () => {
       })
       expect(result?.args.subagent_type).toBe(subagentType)
     }
+  })
+
+  it("extracts OpenCode/Kilo subagents from the generated Task catalog", () => {
+    const catalog = extractHostSubagentCatalog([{
+      name: "task",
+      description: [
+        "Delegate work to a subagent.",
+        "Available agent types and the tools they have access to:",
+        "- general: General-purpose work.",
+        "- explore: Local codebase search.",
+        "- scout: External docs and dependency source.",
+      ].join("\n"),
+      inputSchema: { type: "object", properties: { subagent_type: { type: "string" } } },
+    }])
+
+    expect(catalog).toEqual({
+      executor: "task",
+      agents: [
+        { name: "general", description: "General-purpose work." },
+        { name: "explore", description: "Local codebase search." },
+        { name: "scout", description: "External docs and dependency source." },
+      ],
+      complete: true,
+    })
+  })
+
+  it("extracts MiMo subagents from Actor's nested dynamic enum", () => {
+    const catalog = extractHostSubagentCatalog([{
+      name: "actor",
+      description: [
+        "Launch an actor.",
+        "Available agent types and the tools they have access to:",
+        "- general: General work.",
+        "- explore: Local search.",
+        "- reviewer: Configured subagent.",
+        "- all-mode-agent: Listed in prose but rejected by Actor's enum.",
+      ].join("\n"),
+      inputSchema: {
+        oneOf: [{
+          properties: {
+            operation: {
+              properties: {
+                subagent_type: { type: "string", enum: ["general", "explore", "reviewer"] },
+              },
+            },
+          },
+        }],
+      },
+    }, { name: "task", description: "Track work items" }])
+
+    expect(catalog.executor).toBe("actor")
+    expect(catalog.complete).toBe(true)
+    expect(catalog.agents.map((agent) => agent.name)).toEqual(["general", "explore", "reviewer"])
+  })
+
+  it("resolves exact custom agents before semantic fallbacks", () => {
+    const catalog = {
+      executor: "task" as const,
+      agents: ["general", "explore", "scout", "bugbot", "reviewer", "unspecified"]
+        .map((name) => ({ name })),
+      complete: true,
+    }
+
+    expect(resolveCursorSubagentType("reviewer", catalog)).toBe("reviewer")
+    expect(resolveCursorSubagentType("bugbot", catalog)).toBe("bugbot")
+    expect(resolveCursorSubagentType("cursor-guide", catalog)).toBe("scout")
+    expect(resolveCursorSubagentType("explore", catalog)).toBe("explore")
+    expect(resolveCursorSubagentType("unspecified", catalog)).toBe("general")
+    expect(resolveCursorSubagentType("future-cursor-agent", catalog)).toBe("general")
+  })
+
+  it("does not invent a generic recipient when a complete catalog omits general", () => {
+    expect(resolveCursorSubagentType("unspecified", {
+      executor: "task",
+      agents: [{ name: "explore" }],
+      complete: true,
+    })).toBeUndefined()
   })
 
   it("maps Cursor-native bugbot review tasks to OpenCode explore", () => {
@@ -587,6 +674,52 @@ describe("parseExecServerMessage", () => {
       subagent_type: "explore",
     })
     expect(result?.localError).toBeUndefined()
+  })
+
+  it("routes native subagent exec through MiMo actor when actor is advertised", () => {
+    const parsed = parseExecServerMessage({
+      id: 35,
+      subagent_args: {
+        prompt: "Inspect the MCP import bridge",
+        subagent_type: "bugbot",
+        resume_agent_id: "actor_previous",
+        run_in_background: true,
+      },
+    })
+    expect(parsed).toBeDefined()
+    remapNativeSubagentForCatalog(parsed!, ["actor", "task", "read"])
+    expect(parsed).toMatchObject({
+      toolName: "actor",
+      resultField: "subagent_result",
+      args: {
+        operation: {
+          action: "spawn",
+          description: "Inspect the MCP import bridge",
+          prompt: "Inspect the MCP import bridge",
+          subagent_type: "explore",
+          actor_id: "actor_previous",
+        },
+      },
+    })
+  })
+
+  it("uses enabled Kilo scout for Cursor guide requests", () => {
+    const parsed = parseExecServerMessage({
+      id: 36,
+      subagent_args: {
+        prompt: "Inspect upstream package documentation",
+        subagent_type: "cursor-guide",
+      },
+    })
+    remapNativeSubagentForCatalog(parsed!, ["task"], {
+      executor: "task",
+      agents: [{ name: "general" }, { name: "explore" }, { name: "scout" }],
+      complete: true,
+    })
+    expect(parsed).toMatchObject({
+      toolName: "task",
+      args: { subagent_type: "scout" },
+    })
   })
 
   it("maps every canonical Pi exec request to its offset result field", () => {


### PR DESCRIPTION
Cursor's model often hallucinates file paths and issues read calls for directories or non-existent files. The native Cursor CLI validates the target before execution — stat'ing the resolved path and returning a typed `ReadResult` oneof case (`file_not_found`, `invalid_file`) on the exec channel. The model sees a structured observation and adjusts.

This change mirrors that behavior in the provider: read targets are resolved against the workspace root (untildify + `path.resolve`), stat'd, and if the file genuinely doesn't exist or isn't a regular file, a typed result is written back to the held-open Cursor exec channel — OpenCode never executes the call and the user never sees a permission prompt for a file that never existed.

**Key points:**
- Only `read` operations are checked — write/edit creation is unaffected
- The edit-handshake new-file read (`recoverMissingEditRead`) fires first, so creating a file via edit still works
- Typed oneof cases match the CLI proto: `file_not_found` (ENOENT), `invalid_file` (directory or non-regular file)
- `EACCES`/`EPERM` fall through to OpenCode so genuine permission decisions are never masked

Fixes #15