### PR TITLE
fix: support apply_patch hosts and report opencode's 50 KB read cap (#18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ OpenCode
 | Request context | `src/context/` | Rules, skills, agents, plugins, git, layout, env |
 | Host paths | `src/context/paths.ts` | Host cache root (`cacheDir` / OCP detect / MiMo·Kilo·OpenCode heuristic); project metadata under `<host-cache>/projects/<slug>/` |
 | Wire protocol | `src/protocol/` | Framing, messages, tools, thinking, checksums, device id |
+| Patch synthesis | `src/protocol/apply-patch.ts` | `apply_patch` envelopes for hosts that withhold `edit`/`write` |
 | Transport | `src/transport/connect.ts` | HTTP/2 bidi + unary RPC |
 
 Package exports:
@@ -109,7 +110,9 @@ When changing rule/skill discovery, keep parity with OpenCode behavior and updat
 - **URL options:** `apiBaseURL` (auth/models/GetServerConfig) vs `agentBaseURL` (Run stream) are separate. Legacy `baseURL` aliases `agentBaseURL` only.
 - **Host validation:** explicit agent overrides and GetServerConfig results must be HTTPS `*.cursor.sh`; reject others.
 - **Telemetry:** `GetServerConfig` sends `telem_enabled: false` by default; opt in via `telemetryEnabled` or `CURSOR_GET_SERVER_CONFIG_TELEMETRY`.
-- **Tool results:** strip OpenCode’s `read` XML envelope before returning content to Cursor so the model cannot echo wrappers into writes.
+- **Tool results:** strip OpenCode’s `read` XML envelope before returning content to Cursor so the model cannot echo wrappers into writes. Stripping must not also drop the truncation footer's *meaning*: OpenCode caps reads at 50 KB (`tool/read.ts` `MAX_BYTES`), so re-state the cap or the model treats a capped read as the whole file. Native `read_args` → `read_result` is the path models actually use (verified live for `gpt-5.4-mini` and `grok-4.5`); its structured `truncated` flag is **not** sufficient on its own, so the content also carries a `[Partial read: …]` marker. `mcp_result` gets a separate notice item and Pi reads get structured `truncation`. Never mark a read the caller bounded itself with `offset`/`limit`.
+- **Write content:** `WriteArgs` has six fields. `file_bytes` (#5) carries the content whenever Cursor sends bytes instead of `file_text`, decoded per `encoding_hint` (#6); Cursor's own executor prefers bytes when non-empty. Never re-add those two to `CURSOR_INTERNAL_KEYS` — they are content, not transport metadata.
+- **Edit-tool substitution:** OpenCode 1.x drops `edit`/`write` from the catalog and advertises `apply_patch` for `gpt-*` model ids. `remapEditToolsForCatalog` translates Cursor's native write/edit exec requests into patch envelopes, keyed only off the advertised set — never off a model id or host version. Rationale and upstream citations live in `src/protocol/apply-patch.ts`; watch items of the same shape are 2.0's missing `task` tool and the pre-announced `bash` rename.
 - **Device identity:** stable OS-derived device ids (CLI-shaped); inventing new fingerprints risks “too many devices” errors.
 - **Session lifecycle:** `SessionManager` holds a Cursor Run open past `doStream` returning whenever a tool exec is still pending, so a later continuation can resume it. Registering a *new* Run for the same `openCodeSessionId` closes any still-open prior Run for that id (`superseded-by-new-run`) — callers that abandon a Run and retry with a fresh one instead of delivering the continuation must not leak the old Run's stream. `maxOpenSessions` (default 24) is a hard backstop: exceeding it force-closes the oldest open session (`open-session-cap-exceeded`) rather than accumulating streams until Cursor's server closes the whole shared HTTP/2 connection.
 - **Personal use:** private Cursor agent protocol; account you own; API can change without notice.

--- a/README.md
+++ b/README.md
@@ -350,9 +350,17 @@ OpenCode
 
 ### Injected system guidance
 
-The provider adds OpenCode-specific system guidance to normal tool-capable conversations, including tool availability, canonical workspace-path grounding, and preferring `edit` / `write` over shell-based file mutation when those tools are available. Compaction keeps its dedicated prompt unchanged.
+The provider adds OpenCode-specific system guidance to normal tool-capable conversations, including tool availability, canonical workspace-path grounding, and preferring `edit` / `write` (or `apply_patch`, when the host advertises that instead) over shell-based file mutation when those tools are available. Compaction keeps its dedicated prompt unchanged.
 
 If this guidance causes issues, update `buildOpenCodeInteractionGuidance` in [`src/language-model.ts`](src/language-model.ts) and its focused coverage in [`test/prompt-history.test.ts`](test/prompt-history.test.ts).
+
+### `apply_patch` models (GPT-5 and friends)
+
+OpenCode 1.x does not simply add `apply_patch` for GPT-series models — it **removes** `edit` and `write` from the tool catalog and advertises `apply_patch` in their place (`ToolRegistry.tools`; the model id must contain `gpt-` and neither `oss` nor `gpt-4`). Cursor keeps sending its native write/edit requests regardless, so without translation every file change on a `gpt-5*` model is refused as an unavailable tool.
+
+The provider translates transparently: a native write becomes an `*** Add File:` patch, and a Pi edit becomes a minimal `*** Update File:` chunk widened to whole lines. This is keyed purely off what the host advertises — it is inert whenever `edit`/`write` are offered normally, and inert again when the host offers neither those nor `apply_patch`. An edit that cannot be expressed faithfully (target unreadable, or the text to replace is absent or ambiguous) is refused with a specific message rather than applied to the wrong region.
+
+OpenCode 2.0 does not perform this substitution, so the path is 1.x-only in practice. See [`src/protocol/apply-patch.ts`](src/protocol/apply-patch.ts) for the upstream references.
 
 ### Native subagent routing
 
@@ -412,6 +420,7 @@ Project `instructions` may reference absolute or `~/` paths (OpenCode parity). S
 - **Compaction resets Cursor conversation state** — the classic plugin marks OpenCode's `compaction` agent explicitly. On those turns the provider mints an isolated Cursor `conversation_id`, drops the prior checkpoint + KV blobs, preserves real tool outputs as OpenCode-host observations in the seed history, and re-advertises the session's last tool catalog while refusing execution during the summary itself. The first normal turn then rebases once more onto a fresh conversation seeded with OpenCode's compacted prompt and normal system instructions, so the summary-agent checkpoint cannot suppress later tool calls. Ordinary no-tool / `toolChoice:none` calls do not reset conversation state.
 - **Conversation bindings and compaction catalogs are bounded** — process-global per-session bindings, prior tool catalogs, and pending post-compaction rebases use a 256-session LRU bound. Evicting a conversation binding also drops its checkpoint and KV blobs.
 - **Interrupted Runs resume from checkpoints** — a remote EOF, Connect end-stream, or trailer error is never emitted as a successful `stop`. When the failed Run produced an eligible checkpoint, the provider opens a new RPC for the same conversation and sends that state with `ResumeAction`, so completed text and tool work are not replayed. Before any stateful output, an interruption without a checkpoint can still rebase from OpenCode history. Stateful interruptions without a checkpoint are surfaced because replay would be ambiguous; retry exhaustion remains explicit. A transport closure after `turn_ended` is treated as successful completion.
+- **Large reads are capped at 50 KB by OpenCode, and the cap is reported** — OpenCode's `read` tool stops at `MAX_BYTES = 50 * 1024`, cutting on a whole-line boundary, and appends `(Output capped at 50 KB. Showing lines X-Y. Use offset=N to continue.)`. The provider strips that envelope before returning content to Cursor so the model cannot echo wrappers into a later write, but it re-states the cap: a capped native read appends a `[Partial read: …]` marker after the content, a capped MCP read gets a separate notice content item, and a Pi read carries structured `PiReadExecSuccess.truncation`. The structured `truncated` flag alone is not enough — verified against live `gpt-5.4-mini` and `grok-4.5` sessions, both of which asserted "highly confident" that partial content was the whole file until the textual marker was added. Deliberately paged reads (explicit `offset`/`limit`) are not marked. Without that signal the model treats a capped read as the whole file and rewrites it truncated, discarding everything past the cap. The cap is hardcoded in OpenCode's read tool — it is not the configurable `tool_output.max_bytes`, which governs `Truncate.Service` and not read's line accumulation — so the only lever is paging with `offset`. Prefer `edit` over whole-file `write` on files above 50 KB.
 - **No fallback models** — if Cursor’s `AvailableModels` API is unreachable and there is no local cache, the provider exposes no models.
 
 ## License

--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -28,6 +28,7 @@ import {
   extractHostSubagentCatalog,
   resolveCustomWebToolAlias,
   remapNativeSubagentForCatalog,
+  remapEditToolsForCatalog,
   CUSTOM_WEBFETCH_TOOL,
   CUSTOM_WEBSEARCH_TOOL,
   type OpencodeToolDef,
@@ -1140,7 +1141,9 @@ export async function pump(
       !displayCallId ||
       parsed.resultField !== "read_result" ||
       parsed.toolName !== "read" ||
-      !advertisedToolNameSet.has("write")
+      // `apply_patch` is the substitute this host offers when it withholds
+      // `write` — the follow-up write_args is remapped onto it either way.
+      !(advertisedToolNameSet.has("write") || advertisedToolNameSet.has("apply_patch"))
     ) return false
 
     const stored = session.displayToolCalls.get(displayCallId)
@@ -1594,6 +1597,14 @@ export async function pump(
             parsed.toolName = executableToolName
           }
           remapNativeSubagentForCatalog(parsed, advertisedToolNameSet, session.subagentCatalog)
+          // Hosts that advertise `apply_patch` in place of `edit`/`write` (see
+          // protocol/apply-patch.ts) still receive Cursor's native write/edit
+          // exec requests. Translate before the unavailable-tool check below.
+          remapEditToolsForCatalog(
+            parsed,
+            advertisedToolNameSet,
+            workspaceRootFromRequestContext(session.requestContext),
+          )
         }
         const displayCallId = extractExecDisplayCallId(esm)
         trace(`exec: id=${parsed?.id} variant=${parsed ? Object.keys(parsed).join(",") : "none"} toolName=${parsed?.toolName} resultField=${parsed?.resultField}`)
@@ -1912,6 +1923,13 @@ export function buildOpenCodeInteractionGuidance(
       names.has("edit")
         ? "- For file changes, use OpenCode `edit` for targeted changes to existing files and `write` to create files or intentionally replace complete contents; do not use shell, Python, or heredocs to change file content while these tools are available."
         : "- Use OpenCode `write` for file-content changes; do not use shell, Python, or heredocs to change file content while it is available.",
+    )
+  } else if (names.has("apply_patch")) {
+    // This host withheld `edit`/`write` and offers `apply_patch` instead. Native
+    // Cursor write/edit requests are translated into it, so say so rather than
+    // leaving the turn with no file-editing guidance at all.
+    instructions.push(
+      "- Use OpenCode `apply_patch` for file-content changes; do not use shell, Python, or heredocs to change file content while it is available. Cursor-native write and edit requests are accepted and converted to `apply_patch` automatically.",
     )
   }
   return [

--- a/src/protocol/apply-patch.ts
+++ b/src/protocol/apply-patch.ts
@@ -1,0 +1,185 @@
+/**
+ * Synthesis of OpenCode `apply_patch` envelopes from Cursor's native write/edit
+ * exec requests.
+ *
+ * ## Why this exists
+ *
+ * OpenCode 1.x does not merely *add* `apply_patch` for GPT models — it removes
+ * `edit` and `write` from the catalog in exchange. From
+ * `packages/opencode/src/tool/registry.ts` (`ToolRegistry.tools`):
+ *
+ * ```ts
+ * // use apply tool in same format as codex
+ * const usePatch =
+ *   input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")
+ * if (tool.id === ApplyPatchTool.id) return usePatch
+ * if (tool.id === EditTool.id || tool.id === WriteTool.id) return !usePatch
+ * ```
+ *
+ * The predicate runs on the *API* model id, so every Cursor `gpt-5*` model
+ * matches (and, as a quirk of substring matching, `gpt-3.5-*` does too while
+ * `gpt-4o` does not).
+ *
+ * Upstream context, in case this ever needs revisiting:
+ *
+ * - Introduced by opencode PR #9127 ("apply_patch tool for openai models"). The
+ *   intent is to hand GPT/Codex models the tool surface they were post-trained
+ *   on; the same commit tells the codex system prompt to prefer `apply_patch`.
+ * - The *exclusivity* is deliberate. On opencode issue #34491 a maintainer
+ *   describes the gate as a "band-aid", "intentionally minimal", whose purpose
+ *   is that "GPT no longer receives edit + write + apply_patch simultaneously",
+ *   and notes that a plugin-side opt-out "isn't feasible today".
+ * - opencode issue #19942 reported exactly this hazard — model-conditional tool
+ *   substitution makes model-agnostic integrations impossible — and was closed
+ *   `not_planned` by a stale bot.
+ * - opencode issue #35408 (open, milestone 2.0) proposes a
+ *   `ctx.session.context(...)` hook exposing a mutable tool roster, and lists
+ *   "Select `apply_patch` versus `edit` + `write`" as work to move out of the
+ *   registry. Once that lands, a host-side opt-out replaces this shim.
+ * - OpenCode 2.0 (`packages/core`) has **no** such gate: `apply_patch`, `edit`
+ *   and `write` are all registered unconditionally in `tool/builtins.ts`. This
+ *   translation is therefore 1.x-only in practice, but it is keyed off the
+ *   advertised set rather than a version check, so it simply never fires on 2.0.
+ *
+ * ## Why translation, not advertisement
+ *
+ * `toolsToDescriptors` forwards every advertised host tool to Cursor verbatim,
+ * so `opencode-apply_patch` already appears in Cursor's catalog whenever
+ * OpenCode advertises it, and an `mcp_args` call naming it already executes.
+ * What breaks is Cursor's *native* write/edit channel (`write_args`,
+ * `pi_edit_args`), which this provider resolves to the fixed host names
+ * `write`/`edit`.
+ *
+ * Translating on our side is the only option: Cursor's agent protocol has no
+ * patch-format edit tool at all (its `ToolCall` oneof offers whole-file
+ * `edit_tool_call`/`write_args` and substring `pi_edit_tool_call`/`pi_edit_args`;
+ * `apply_agent_diff_tool_call` is unrelated — it applies a cloud agent's diff by
+ * `agent_id`). Cursor's CLI also contains no model-conditional branching
+ * whatsoever, and `ModelDetails` carries no tool-capability flags, so the same
+ * native requests arrive for every model. Those names are absent from
+ * the catalog, so the request is refused before it reaches OpenCode.
+ *
+ * ## Format notes (verified against `packages/opencode/src/patch/index.ts`)
+ *
+ * - `*** Add File:` **overwrites an existing file** — the tool's `add` case uses
+ *   `oldContent = ""` and never stats the target (upstream test: "adds file
+ *   overwriting existing file"). A whole-file write therefore needs no diff and
+ *   no existence check.
+ * - An empty `@@` header is a valid chunk start: the parser stores
+ *   `change_context: contextLine || undefined`, and a missing context simply
+ *   means "match `old_lines` from the current scan position".
+ * - Every payload line is prefixed with `+`, `-`, or a space, and the parser
+ *   only breaks on *unprefixed* `***` / `@@`. Content lines that themselves
+ *   begin with `***` or `@@` therefore survive a round trip unharmed.
+ * - `Add File` content is rejoined with `\n` and normalized to exactly one
+ *   trailing newline. A write of content with no trailing newline gains one.
+ * - Update chunks match **whole lines** via `seekSequence`, unlike OpenCode
+ *   `edit`, which is substring-based. Substring edits must be expanded to line
+ *   boundaries before they can be expressed as a patch — see `planSubstringEdit`.
+ * - Renames are rejected by OpenCode 2.0's implementation ("apply_patch moves
+ *   are not supported yet"), so `*** Move to:` is never emitted here.
+ */
+
+export const APPLY_PATCH_TOOL = "apply_patch"
+
+const BEGIN = "*** Begin Patch"
+const END = "*** End Patch"
+
+/** One `@@` chunk: replace `oldLines` with `newLines`. */
+export type UpdateChunk = {
+  oldLines: string[]
+  newLines: string[]
+}
+
+/**
+ * Whole-file write as `*** Add File:`. Valid whether or not the target exists —
+ * OpenCode's add case overwrites unconditionally.
+ */
+export function buildAddFilePatch(filePath: string, content: string): string {
+  const lines = splitLines(content)
+  return [BEGIN, `*** Add File: ${filePath}`, ...lines.map((line) => `+${line}`), END].join("\n")
+}
+
+/** Targeted replacement as `*** Update File:` with one `@@` chunk per change. */
+export function buildUpdateFilePatch(filePath: string, chunks: UpdateChunk[]): string {
+  const body: string[] = []
+  for (const chunk of chunks) {
+    body.push("@@")
+    for (const line of chunk.oldLines) body.push(`-${line}`)
+    for (const line of chunk.newLines) body.push(`+${line}`)
+  }
+  return [BEGIN, `*** Update File: ${filePath}`, ...body, END].join("\n")
+}
+
+export type SubstringEditPlan =
+  | { ok: true; chunks: UpdateChunk[] }
+  | { ok: false; reason: string }
+
+/**
+ * Expand a substring replacement to the whole lines it touches, because
+ * `apply_patch` matches line sequences rather than substrings.
+ *
+ * Refuses rather than guessing: an absent match, or an ambiguous one without
+ * `replaceAll`, would otherwise be silently applied to the wrong region.
+ */
+export function planSubstringEdit(
+  source: string,
+  oldString: string,
+  newString: string,
+  replaceAll = false,
+): SubstringEditPlan {
+  if (oldString === "") return { ok: false, reason: "the text to replace is empty" }
+
+  const offsets: number[] = []
+  for (let at = source.indexOf(oldString); at !== -1; at = source.indexOf(oldString, at + oldString.length)) {
+    offsets.push(at)
+  }
+  if (offsets.length === 0) return { ok: false, reason: "the text to replace was not found in the file" }
+  if (offsets.length > 1 && !replaceAll) {
+    return {
+      ok: false,
+      reason: `the text to replace appears ${offsets.length} times; it must be unique`,
+    }
+  }
+
+  const targets = replaceAll ? offsets : offsets.slice(0, 1)
+  const chunks: UpdateChunk[] = []
+  let previousEnd = -1
+  for (const offset of targets) {
+    const start = lineStart(source, offset)
+    const end = lineEnd(source, offset + oldString.length)
+    // Overlapping expansions would emit the same original lines twice, and the
+    // second chunk could never match after the first replaced them.
+    if (start < previousEnd) {
+      return { ok: false, reason: "overlapping replacements cannot be expressed as a patch" }
+    }
+    previousEnd = end
+
+    const before = source.slice(start, offset)
+    const after = source.slice(offset + oldString.length, end)
+    chunks.push({
+      oldLines: splitLines(source.slice(start, end)),
+      newLines: splitLines(before + newString + after),
+    })
+  }
+  return { ok: true, chunks }
+}
+
+/**
+ * Split into patch payload lines. A trailing newline is dropped so it is not
+ * emitted as a spurious empty line — OpenCode re-adds exactly one on apply.
+ */
+function splitLines(text: string): string[] {
+  const normalized = text.endsWith("\n") ? text.slice(0, -1) : text
+  return normalized.split("\n")
+}
+
+function lineStart(source: string, offset: number): number {
+  const at = source.lastIndexOf("\n", offset - 1)
+  return at === -1 ? 0 : at + 1
+}
+
+function lineEnd(source: string, offset: number): number {
+  const at = source.indexOf("\n", offset)
+  return at === -1 ? source.length : at
+}

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -512,16 +512,23 @@ export function createMessageTypes(): protobuf.Root {
     [{ name: "result", fields: ["success", "error"] }],
   )
 
+  // agent.v1.WriteArgs. Cursor's own LocalWriteExecutor reads `file_bytes`
+  // first and only falls back to `file_text`, so a write whose content arrives
+  // as bytes decodes to an empty string unless field 5 is declared here.
   addType(root, "WriteArgs", [
     { id: 1, name: "path", type: "string" },
     { id: 2, name: "file_text", type: "string" },
     { id: 3, name: "tool_call_id", type: "string" },
+    { id: 4, name: "return_file_content_after_write", type: "bool" },
+    { id: 5, name: "file_bytes", type: "bytes" },
+    { id: 6, name: "encoding_hint", type: "string" },
   ])
 
   addType(root, "WriteSuccess", [
     { id: 1, name: "path", type: "string" },
     { id: 2, name: "lines_created", type: "int32" },
     { id: 3, name: "file_size", type: "int32" },
+    { id: 4, name: "file_content_after_write", type: "string" },
   ])
   addType(root, "WriteError", [
     { id: 1, name: "path", type: "string" },
@@ -566,7 +573,26 @@ export function createMessageTypes(): protobuf.Root {
     ],
     [{ name: "result", fields: ["success", "error", "rejected"] }],
   )
-  addType(root, "PiOutputSuccess", [{ id: 1, name: "output", type: "string" }])
+  // agent.v1.PiTruncation. Every Pi *ExecSuccess shares output(1)+truncation(2)
+  // and only diverges at field 3, so the shared PiOutputSuccess can carry it.
+  // Cursor's own CLI always reports truncation rather than silently shortening
+  // a payload; emitting this keeps a capped read distinguishable from a
+  // complete one.
+  addType(root, "PiTruncation", [
+    { id: 1, name: "truncated", type: "bool" },
+    { id: 2, name: "truncated_by", type: "string" },
+    { id: 3, name: "total_lines", type: "uint32" },
+    { id: 4, name: "output_lines", type: "uint32" },
+    { id: 5, name: "output_bytes", type: "uint32" },
+    { id: 6, name: "max_lines", type: "uint32" },
+    { id: 7, name: "max_bytes", type: "uint32" },
+    { id: 8, name: "first_line_exceeds_limit", type: "bool" },
+    { id: 9, name: "last_line_partial", type: "bool" },
+  ])
+  addType(root, "PiOutputSuccess", [
+    { id: 1, name: "output", type: "string" },
+    { id: 2, name: "truncation", type: "PiTruncation" },
+  ])
   addType(root, "PiExecError", [{ id: 1, name: "error", type: "string" }])
   addType(root, "PiExecRejected", [{ id: 1, name: "reason", type: "string" }])
   for (const resultType of [

--- a/src/protocol/tools.ts
+++ b/src/protocol/tools.ts
@@ -8,6 +8,12 @@ import { ensureOpencodeProjectDir } from "../context/paths.js"
 import { trace, traceRequestContextPaths } from "../debug.js"
 import { cursorExecVariantByRequestName } from "./exec-variants.js"
 import {
+  APPLY_PATCH_TOOL,
+  buildAddFilePatch,
+  buildUpdateFilePatch,
+  planSubstringEdit,
+} from "./apply-patch.js"
+import {
   BACKGROUND_SHELL_MARKER,
   buildBackgroundShellCommand,
   type CursorShellOutcome,
@@ -336,11 +342,15 @@ const CURSOR_INTERNAL_KEYS = new Set([
   "close_stdin",
   "output_notification",
   "file_output_threshold_bytes",
+  // WriteArgs #4. A request for WriteSuccess.file_content_after_write, which we
+  // do not populate; harmless to omit, but it is not tool input.
   "return_file_content_after_write",
-  "file_bytes",
-  "encoding_hint",
   "ignore",
 ])
+// WriteArgs #5/#6 are deliberately NOT internal: `file_bytes` carries the file
+// content itself whenever Cursor sends it instead of `file_text` (its own
+// LocalWriteExecutor prefers bytes when non-empty), and `encoding_hint` is how
+// that payload is decoded. The `write` mapping consumes both explicitly.
 
 /** Required content fields where an empty string is meaningful (for example, truncating a file). */
 const PRESERVE_EMPTY_STRING_KEYS = new Set([
@@ -582,6 +592,103 @@ export function remapNativeSubagentForCatalog(
       ...(resumeAgentId ? { actor_id: resumeAgentId } : {}),
     },
   }
+}
+
+/** Matches Cursor's own pre-write read threshold (`local-exec` 52428800). */
+const MAX_EDIT_SOURCE_BYTES = 50 * 1024 * 1024
+
+/**
+ * Express a native Cursor write/edit as `apply_patch` when the host swapped the
+ * edit-tool family out from under us.
+ *
+ * OpenCode 1.x removes `edit` and `write` from the catalog for GPT models and
+ * advertises `apply_patch` in their place — see the module comment in
+ * `./apply-patch.ts` for the upstream reasoning and citations. Cursor keeps
+ * using its native write/edit exec channel regardless, so without this the
+ * request is refused as an unavailable tool and the model loses the ability to
+ * change files at all.
+ *
+ * Keyed purely off the advertised set: this is inert whenever the host offers
+ * `write`/`edit` normally, and equally inert when it offers neither those nor
+ * `apply_patch` (the caller's unavailable-tool rejection still applies).
+ */
+export function remapEditToolsForCatalog(
+  parsed: ParsedExecRequest,
+  advertisedToolNames: Iterable<string>,
+  workspaceRoot?: string,
+): void {
+  if (parsed.toolName !== "write" && parsed.toolName !== "edit") return
+  const advertised = new Set(advertisedToolNames)
+  if (advertised.has(parsed.toolName) || !advertised.has(APPLY_PATCH_TOOL)) return
+
+  const requested = parsed.toolName
+  const filePath = str(parsed.args.filePath)
+  const refuse = (reason: string) => {
+    parsed.toolName = APPLY_PATCH_TOOL
+    parsed.args = {}
+    parsed.localError =
+      `Cursor ${requested} request cannot be expressed as an apply_patch call: ${reason}. ` +
+      "The host advertises `apply_patch` instead of `edit`/`write` for this model."
+  }
+
+  if (!filePath) {
+    refuse("no target path was provided")
+    return
+  }
+
+  let patchText: string
+  if (requested === "write") {
+    const content = stringValue(parsed.args.content)
+    if (content === undefined) {
+      refuse("no file content was provided")
+      return
+    }
+    // `*** Add File:` overwrites an existing target, so a whole-file write maps
+    // directly without reading the current contents or diffing.
+    patchText = buildAddFilePatch(filePath, content)
+  } else {
+    const oldString = stringValue(parsed.args.oldString)
+    const newString = stringValue(parsed.args.newString)
+    if (oldString === undefined || newString === undefined) {
+      refuse("the replacement is missing its old or new text")
+      return
+    }
+    // apply_patch matches whole lines, so a substring edit has to be widened to
+    // the lines it touches — which requires the file the model is editing.
+    const absolute = path.resolve(workspaceRoot ?? process.cwd(), filePath)
+    let source: string
+    try {
+      // Bounded because this read is synchronous on the Run pump. Cursor's own
+      // executor uses the same 50 MB threshold before reading a file it is
+      // about to write.
+      const size = fs.statSync(absolute).size
+      if (size > MAX_EDIT_SOURCE_BYTES) {
+        refuse(`the target file is ${Math.round(size / 1024 / 1024)} MB, too large to patch`)
+        return
+      }
+      source = fs.readFileSync(absolute, "utf8")
+    } catch (e) {
+      refuse(`the target file could not be read (${(e as Error).message})`)
+      return
+    }
+    const plan = planSubstringEdit(
+      source,
+      oldString,
+      newString,
+      parsed.args.replaceAll === true,
+    )
+    if (!plan.ok) {
+      refuse(plan.reason)
+      return
+    }
+    patchText = buildUpdateFilePatch(filePath, plan.chunks)
+  }
+
+  parsed.toolName = APPLY_PATCH_TOOL
+  parsed.args = { patchText }
+  // apply_patch's output does not carry opencode `write`'s <path> tag, so keep
+  // the requested path for the typed Cursor result.
+  parsed.resultMetadata = { ...parsed.resultMetadata, path: filePath }
 }
 
 // ── Extract exec args from ExecServerMessage ──
@@ -840,7 +947,13 @@ export function mapCursorArgsToOpencode(
       const args: Record<string, unknown> = {}
       const filePath = str(cleaned.filePath) ?? str(cleaned.path) ?? str(cleaned.file_path)
       if (filePath) args.filePath = filePath
-      const content = stringValue(cleaned.content) ?? stringValue(cleaned.file_text) ?? stringValue(cleaned.fileText)
+      // Cursor's LocalWriteExecutor prefers `file_bytes` whenever it is
+      // non-empty and only falls back to `file_text`; mirror that order so a
+      // byte-encoded write is not silently seen as empty content.
+      const bytes = bytesValue(cleaned.file_bytes) ?? bytesValue(cleaned.fileBytes)
+      const content = bytes !== undefined
+        ? decodeWriteBytes(bytes, str(cleaned.encoding_hint) ?? str(cleaned.encodingHint))
+        : stringValue(cleaned.content) ?? stringValue(cleaned.file_text) ?? stringValue(cleaned.fileText)
       if (content !== undefined) args.content = content
       return { toolName: "write", args }
     }
@@ -902,6 +1015,32 @@ function str(v: unknown): string | undefined {
 
 function stringValue(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined
+}
+
+/** A non-empty protobuf `bytes` field, or undefined when absent/empty. */
+function bytesValue(v: unknown): Uint8Array | undefined {
+  if (v instanceof Uint8Array) return v.length > 0 ? v : undefined
+  if (Array.isArray(v) && v.every((b) => typeof b === "number")) {
+    return v.length > 0 ? Uint8Array.from(v) : undefined
+  }
+  return undefined
+}
+
+/**
+ * Decode `WriteArgs.file_bytes`. `encoding_hint` names the file's original
+ * encoding; OpenCode's `write` takes a string, so anything Node cannot decode
+ * falls back to UTF-8 rather than dropping the write.
+ */
+function decodeWriteBytes(bytes: Uint8Array, encodingHint?: string): string {
+  const encoding = encodingHint?.trim().toLowerCase().replace(/[_ ]/g, "-")
+  if (encoding && encoding !== "utf-8" && encoding !== "utf8") {
+    try {
+      return new TextDecoder(encoding, { fatal: false }).decode(bytes)
+    } catch {
+      trace(`write: unsupported encoding_hint ${JSON.stringify(encodingHint)} — decoding as utf-8`)
+    }
+  }
+  return new TextDecoder("utf-8").decode(bytes)
 }
 
 function num(v: unknown): number | undefined {
@@ -1260,16 +1399,22 @@ export function buildTypedExecResult(
       if (error) return { error: { path: readPath, error } }
       // Strip opencode's <path>/<content> envelope so Cursor's model receives
       // raw file content and can't echo the wrapper into subsequent writes.
-      // reads route here only for native read_args; most arrive via mcp_result.
+      // Cursor's native read_args lands here; `mcp_args` reads land in
+      // mcp_result. Live captures show gpt-5.4-mini and grok-4.5 both use the
+      // native channel, so this is the path that matters in practice.
       const content = unwrapReadOutput(output)
       const statPath = extractPathTag(output) ?? readPath
       const outputMetadata = parseOpenCodeReadMetadata(output)
       const totalLines = outputMetadata.totalLines ?? readFileLineCount(statPath) ?? countLines(content)
       const rangeApplied = readRangeApplied(resultMetadata, totalLines)
+      // `truncated` alone is not enough: it is set here, and models still assert
+      // the partial content is the whole file. Cursor's own executor puts the
+      // limit marker in the output text for the same reason, so append one.
+      const notice = readTruncationNotice(output, resultMetadata)
       return {
         success: {
           path: readPath,
-          content,
+          content: notice ? `${content}\n\n${notice}` : content,
           total_lines: totalLines,
           file_size: readFileSize(statPath),
           truncated: readOutputTruncated(resultMetadata, outputMetadata, totalLines),
@@ -1300,22 +1445,31 @@ export function buildTypedExecResult(
         },
       }
     }
-    case "write_result":
-      if (error) return { error: { path: "", error } }
+    case "write_result": {
+      // `apply_patch` output carries no <path> tag, so prefer the path recorded
+      // when the request was remapped away from `write`.
+      const remappedPath = str(resultMetadata?.path)
+      if (error) return { error: { path: remappedPath ?? "", error } }
       return {
         success: {
-          path: extractPathTag(output) ?? "",
+          path: remappedPath ?? extractPathTag(output) ?? "",
           lines_created: countLines(output),
           file_size: output.length,
         },
       }
+    }
     case "pi_write_result":
       // PiWriteExecSuccess is just { output }; error is { error }.
       if (error) return { error: { error } }
       return { success: { output: output || "Wrote file successfully." } }
-    case "pi_read_result":
+    case "pi_read_result": {
       if (error) return { error: { error } }
-      return { success: { output: unwrapReadOutput(output) } }
+      // Pi results carry truncation structurally (PiReadExecSuccess field 2),
+      // which is how Cursor's own executors report a capped payload.
+      const content = unwrapReadOutput(output)
+      const truncation = readTruncationMessage(output, content)
+      return { success: { output: content, ...(truncation ? { truncation } : {}) } }
+    }
     case "pi_bash_result":
     case "pi_edit_result":
     case "pi_grep_result":
@@ -1380,20 +1534,28 @@ export function buildTypedExecResult(
         },
       }
     }
-    case "mcp_result":
+    case "mcp_result": {
       if (error) return { error: { error } }
       // opencode built-ins (read/write/grep/…) are advertised as MCP tools, so
       // a read call returns through mcp_result. Scope the unwrap to toolName
       // "read" so a non-read MCP tool whose output merely contains a
       // "<content>"-like block is never rewritten.
+      if (toolName !== "read") {
+        return { success: { content: [{ text: { text: output } }], is_error: false } }
+      }
+      // Carry the truncation notice as its own content item: the file content
+      // item stays byte-exact, so it can still never be echoed into a write.
+      const notice = readTruncationNotice(output)
       return {
         success: {
           content: [
-            { text: { text: toolName === "read" ? unwrapReadOutput(output) : output } },
+            { text: { text: unwrapReadOutput(output) } },
+            ...(notice ? [{ text: { text: notice } }] : []),
           ],
           is_error: false,
         },
       }
+    }
     case "subagent_result": {
       const task = parseOpenCodeTaskOutput(output)
       if (error || task.state === "error") {
@@ -1460,21 +1622,122 @@ type OpenCodeReadMetadata = {
   outputCapped?: boolean
 }
 
+/**
+ * Isolate opencode's read footer: the last blank-line-separated block before
+ * the closing `</content>`. Scanning the whole envelope would let a file that
+ * merely *quotes* a footer (this repository's own docs and tests do) pass for a
+ * truncated read. The body can never contain a blank line — every source line
+ * is rendered as `N: …`, so even an empty line keeps its `N: ` prefix.
+ *
+ * Falls back to the full string when the envelope is absent, preserving
+ * behavior for non-standard read output.
+ */
+function readEnvelopeFooter(output: string): string {
+  const close = output.lastIndexOf("\n</content>")
+  if (close === -1) return output
+  const start = output.lastIndexOf("\n\n", close)
+  if (start === -1) return output
+  return output.slice(start + 2, close)
+}
+
 /** Recover full-file metadata before unwrapReadOutput removes OpenCode's footer. */
 function parseOpenCodeReadMetadata(output: string): OpenCodeReadMetadata {
-  const showing = /Showing lines (\d+)-(\d+)(?: of (\d+))?\./.exec(output)
+  const footer = readEnvelopeFooter(output)
+  const showing = /Showing lines (\d+)-(\d+)(?: of (\d+))?\./.exec(footer)
   if (showing) {
     return {
       startLine: Number(showing[1]),
       endLine: Number(showing[2]),
       ...(showing[3] ? { totalLines: Number(showing[3]) } : {}),
-      outputCapped: output.includes("(Output capped at "),
+      outputCapped: footer.includes("(Output capped at "),
     }
   }
-  const complete = /\(End of file - total (\d+) lines?\)/.exec(output)
+  const complete = /\(End of file - total (\d+) lines?\)/.exec(footer)
   if (complete) return { totalLines: Number(complete[1]) }
   return {}
 }
+
+/**
+ * OpenCode's `read` caps output at 50 KB (`tool/read.ts` MAX_BYTES = 50 * 1024)
+ * and cuts on a whole-line boundary, then appends
+ * "(Output capped at 50 KB. Showing lines X-Y. Use offset=N to continue.)".
+ *
+ * `unwrapReadOutput` strips that footer along with the envelope, deliberately:
+ * Cursor's model echoes whatever it is handed straight back into the next
+ * write, so anything left in the content stream can end up written into the
+ * file. But dropping the notice with no replacement is worse — the model then
+ * believes a capped read is the complete file, rewrites it from what it has,
+ * and everything past the cap is destroyed.
+ *
+ * Cursor's own CLI never truncates silently. Its local executor annotates every
+ * capped payload ("50KB limit reached", "[Showing last …KB of line N (50KB
+ * limit). Full output: …]") and returns structured truncation metadata. Mirror
+ * that, keeping the signal out of the file content itself so it still cannot be
+ * echoed into a write.
+ */
+function readTruncationSummary(
+  output: string,
+): { startLine: number; endLine: number; nextOffset: number; capped: boolean; totalLines?: number } | undefined {
+  const meta = parseOpenCodeReadMetadata(output)
+  if (meta.startLine === undefined || meta.endLine === undefined) return undefined
+  // A complete read reports "(End of file …)" and never reaches this shape.
+  if (meta.totalLines !== undefined && meta.endLine >= meta.totalLines && !meta.outputCapped) return undefined
+  return {
+    startLine: meta.startLine,
+    endLine: meta.endLine,
+    nextOffset: meta.endLine + 1,
+    capped: meta.outputCapped === true,
+    ...(meta.totalLines !== undefined ? { totalLines: meta.totalLines } : {}),
+  }
+}
+
+/**
+ * Model-visible replacement for the stripped footer.
+ *
+ * Only for reads the model did not ask to bound. A caller that passed an
+ * explicit offset/limit already knows it asked for a slice — warning there
+ * would cry wolf on every deliberate paged read.
+ */
+function readTruncationNotice(
+  output: string,
+  resultMetadata?: Record<string, unknown>,
+): string | undefined {
+  const summary = readTruncationSummary(output)
+  if (!summary) return undefined
+  const rangeRequested =
+    num(resultMetadata?.offset) !== undefined || num(resultMetadata?.limit) !== undefined
+  if (rangeRequested && !summary.capped) return undefined
+  const range = summary.totalLines !== undefined
+    ? `lines ${summary.startLine}-${summary.endLine} of ${summary.totalLines}`
+    : `lines ${summary.startLine}-${summary.endLine}`
+  return (
+    `[Partial read: the content above is ${range}` +
+    (summary.capped ? ", capped at the host's 50 KB output limit" : "") +
+    `. It is NOT the complete file. Continue with offset=${summary.nextOffset} before ` +
+    `acting on the whole file; writing the content above back would delete everything ` +
+    `after line ${summary.endLine}.]`
+  )
+}
+
+/** agent.v1.PiTruncation for a capped OpenCode read. */
+function readTruncationMessage(
+  output: string,
+  content: string,
+): Record<string, unknown> | undefined {
+  const summary = readTruncationSummary(output)
+  if (!summary) return undefined
+  return {
+    truncated: true,
+    truncated_by: summary.capped ? "bytes" : "lines",
+    ...(summary.totalLines !== undefined ? { total_lines: summary.totalLines } : {}),
+    output_lines: Math.max(0, summary.endLine - summary.startLine + 1),
+    output_bytes: Buffer.byteLength(content, "utf8"),
+    ...(summary.capped ? { max_bytes: OPENCODE_READ_MAX_BYTES } : {}),
+  }
+}
+
+/** `tool/read.ts` MAX_BYTES — mirrored only to report the cap, never to apply it. */
+const OPENCODE_READ_MAX_BYTES = 50 * 1024
 
 function readRangeApplied(
   resultMetadata: Record<string, unknown> | undefined,

--- a/test/apply-patch.test.ts
+++ b/test/apply-patch.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import {
+  buildAddFilePatch,
+  buildUpdateFilePatch,
+  planSubstringEdit,
+} from "../src/protocol/apply-patch.js"
+import {
+  parseExecServerMessage,
+  remapEditToolsForCatalog,
+  buildTypedExecResult,
+} from "../src/protocol/tools.js"
+import {
+  parseDisplayToolCall,
+  resolveBridgedOpenCodeToolCall,
+} from "../src/protocol/tool-call-bridge.js"
+
+let workspace: string
+
+beforeEach(() => {
+  workspace = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-apply-patch-"))
+})
+
+afterEach(() => {
+  fs.rmSync(workspace, { recursive: true, force: true })
+})
+
+describe("apply_patch envelope synthesis", () => {
+  it("writes whole file contents as an Add File hunk", () => {
+    expect(buildAddFilePatch("src/a.ts", "one\ntwo\n")).toBe(
+      ["*** Begin Patch", "*** Add File: src/a.ts", "+one", "+two", "*** End Patch"].join("\n"),
+    )
+  })
+
+  it("does not emit a spurious blank line for a trailing newline", () => {
+    expect(buildAddFilePatch("a.txt", "only\n")).toBe(
+      ["*** Begin Patch", "*** Add File: a.txt", "+only", "*** End Patch"].join("\n"),
+    )
+    expect(buildAddFilePatch("a.txt", "only")).toBe(
+      ["*** Begin Patch", "*** Add File: a.txt", "+only", "*** End Patch"].join("\n"),
+    )
+  })
+
+  it("keeps content lines that look like patch markers", () => {
+    // The parser only breaks on *unprefixed* markers, so `+`/`-` protect these.
+    const content = "*** End Patch\n@@ not a header\n*** Add File: nope\n"
+    expect(buildAddFilePatch("f.md", content)).toBe(
+      [
+        "*** Begin Patch",
+        "*** Add File: f.md",
+        "+*** End Patch",
+        "+@@ not a header",
+        "+*** Add File: nope",
+        "*** End Patch",
+      ].join("\n"),
+    )
+  })
+
+  it("emits an empty-context chunk per update", () => {
+    expect(
+      buildUpdateFilePatch("a.ts", [{ oldLines: ["old"], newLines: ["new"] }]),
+    ).toBe(
+      ["*** Begin Patch", "*** Update File: a.ts", "@@", "-old", "+new", "*** End Patch"].join("\n"),
+    )
+  })
+})
+
+describe("planSubstringEdit", () => {
+  it("expands a partial-line replacement to whole lines", () => {
+    const plan = planSubstringEdit("const a = 1\nconst b = 2\n", "= 2", "= 3")
+    expect(plan).toEqual({
+      ok: true,
+      chunks: [{ oldLines: ["const b = 2"], newLines: ["const b = 3"] }],
+    })
+  })
+
+  it("handles a replacement spanning several lines", () => {
+    const plan = planSubstringEdit("a\nb\nc\n", "b\nc", "x")
+    expect(plan).toEqual({ ok: true, chunks: [{ oldLines: ["b", "c"], newLines: ["x"] }] })
+  })
+
+  it("refuses when the text is absent", () => {
+    const plan = planSubstringEdit("a\n", "zzz", "y")
+    expect(plan.ok).toBe(false)
+  })
+
+  it("refuses an ambiguous match rather than guessing", () => {
+    const plan = planSubstringEdit("dup\ndup\n", "dup", "x")
+    expect(plan).toMatchObject({ ok: false })
+    expect((plan as { reason: string }).reason).toContain("2 times")
+  })
+
+  it("emits one chunk per occurrence for replaceAll", () => {
+    const plan = planSubstringEdit("dup\nmid\ndup\n", "dup", "x", true)
+    expect(plan).toEqual({
+      ok: true,
+      chunks: [
+        { oldLines: ["dup"], newLines: ["x"] },
+        { oldLines: ["dup"], newLines: ["x"] },
+      ],
+    })
+  })
+})
+
+describe("remapEditToolsForCatalog", () => {
+  const writeRequest = (filePath: string, content: string) =>
+    parseExecServerMessage({ id: 7, write_args: { path: filePath, file_text: content } })!
+
+  it("leaves the request alone when write is advertised", () => {
+    const parsed = writeRequest("a.txt", "hi\n")
+    remapEditToolsForCatalog(parsed, ["read", "write", "apply_patch"], workspace)
+    expect(parsed.toolName).toBe("write")
+    expect(parsed.args).toMatchObject({ filePath: "a.txt", content: "hi\n" })
+  })
+
+  it("leaves the request alone when apply_patch is not advertised", () => {
+    const parsed = writeRequest("a.txt", "hi\n")
+    remapEditToolsForCatalog(parsed, ["read", "bash"], workspace)
+    // Still `write`, so the caller's unavailable-tool rejection applies.
+    expect(parsed.toolName).toBe("write")
+    expect(parsed.localError).toBeUndefined()
+  })
+
+  it("converts a native write into an Add File patch", () => {
+    const parsed = writeRequest("a.txt", "hi\n")
+    remapEditToolsForCatalog(parsed, ["read", "apply_patch"], workspace)
+    expect(parsed.toolName).toBe("apply_patch")
+    expect(parsed.resultField).toBe("write_result")
+    expect(parsed.args).toEqual({
+      patchText: ["*** Begin Patch", "*** Add File: a.txt", "+hi", "*** End Patch"].join("\n"),
+    })
+    expect(parsed.resultMetadata).toMatchObject({ path: "a.txt" })
+  })
+
+  it("converts a Pi edit into a minimal Update File patch", () => {
+    fs.writeFileSync(path.join(workspace, "b.ts"), "const a = 1\nconst b = 2\n")
+    const parsed = parseExecServerMessage({
+      id: 8,
+      pi_edit_args: { path: "b.ts", edits: [{ old_text: "= 2", new_text: "= 3" }] },
+    })!
+    remapEditToolsForCatalog(parsed, ["read", "apply_patch"], workspace)
+    expect(parsed.toolName).toBe("apply_patch")
+    expect(parsed.args).toEqual({
+      patchText: [
+        "*** Begin Patch",
+        "*** Update File: b.ts",
+        "@@",
+        "-const b = 2",
+        "+const b = 3",
+        "*** End Patch",
+      ].join("\n"),
+    })
+  })
+
+  it("refuses an edit whose target cannot be read", () => {
+    const parsed = parseExecServerMessage({
+      id: 9,
+      pi_edit_args: { path: "missing.ts", edits: [{ old_text: "a", new_text: "b" }] },
+    })!
+    remapEditToolsForCatalog(parsed, ["read", "apply_patch"], workspace)
+    expect(parsed.toolName).toBe("apply_patch")
+    expect(parsed.localError).toContain("could not be read")
+  })
+
+  it("refuses an ambiguous edit instead of patching the wrong line", () => {
+    fs.writeFileSync(path.join(workspace, "c.ts"), "dup\ndup\n")
+    const parsed = parseExecServerMessage({
+      id: 10,
+      pi_edit_args: { path: "c.ts", edits: [{ old_text: "dup", new_text: "x" }] },
+    })!
+    remapEditToolsForCatalog(parsed, ["read", "apply_patch"], workspace)
+    expect(parsed.localError).toContain("must be unique")
+  })
+
+  it("reports the remapped path in the typed write result", () => {
+    const result = buildTypedExecResult("write_result", "", undefined, "apply_patch", {
+      path: "a.txt",
+    })
+    expect(result).toMatchObject({ success: { path: "a.txt" } })
+  })
+})
+
+describe("display bridge", () => {
+  it("leaves edit_tool_call to the exec channel", () => {
+    // edit_tool_call is not a display-state mirror variant: Cursor follows it
+    // with a real write_args exec request, which remapEditToolsForCatalog
+    // handles. Bridging it here as well would apply the write twice.
+    const display = parseDisplayToolCall("call-1", {
+      edit_tool_call: { path: "d.txt", stream_content: "alpha\n" },
+    })
+    expect(display?.variant).toBe("edit_tool_call")
+    expect(resolveBridgedOpenCodeToolCall(display!, ["read", "apply_patch"])).toBeUndefined()
+  })
+})

--- a/test/payload-truncation.test.ts
+++ b/test/payload-truncation.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "bun:test"
+import {
+  buildTypedExecResult,
+  mapCursorArgsToOpencode,
+  parseExecServerMessage,
+} from "../src/protocol/tools.js"
+import { encodeMessage, decodeMessage } from "../src/protocol/messages.js"
+
+/** Shape of an opencode `read` result, including its trailing footer. */
+function readEnvelope(lines: string[], footer: string, filePath = "big.ts"): string {
+  const body = lines.map((line, i) => `${i + 1}: ${line}`).join("\n")
+  return [
+    `<path>${filePath}</path>`,
+    `<type>file</type>`,
+    "<content>\n" + body,
+    "",
+    footer,
+    "</content>",
+  ].join("\n")
+}
+
+const CAPPED_FOOTER = "(Output capped at 50 KB. Showing lines 1-2. Use offset=3 to continue.)"
+const COMPLETE_FOOTER = "(End of file - total 2 lines)"
+
+describe("read truncation is reported, not silently dropped", () => {
+  it("adds a separate notice content item for a capped MCP read", () => {
+    const output = readEnvelope(["alpha", "beta"], CAPPED_FOOTER)
+    const result = buildTypedExecResult("mcp_result", output, undefined, "read") as {
+      success: { content: Array<{ text: { text: string } }> }
+    }
+    expect(result.success.content).toHaveLength(2)
+    // File content stays byte-exact so it can never be echoed into a write.
+    expect(result.success.content[0].text.text).toBe("alpha\nbeta")
+    const notice = result.success.content[1].text.text
+    expect(notice).toContain("Partial read")
+    expect(notice).toContain("offset=3")
+    expect(notice).toContain("50 KB")
+  })
+
+  it("adds no notice when the read reached end of file", () => {
+    const output = readEnvelope(["alpha", "beta"], COMPLETE_FOOTER)
+    const result = buildTypedExecResult("mcp_result", output, undefined, "read") as {
+      success: { content: unknown[] }
+    }
+    expect(result.success.content).toHaveLength(1)
+  })
+
+  it("leaves non-read MCP output untouched", () => {
+    const result = buildTypedExecResult("mcp_result", "plain output", undefined, "grep") as {
+      success: { content: Array<{ text: { text: string } }> }
+    }
+    expect(result.success.content).toHaveLength(1)
+    expect(result.success.content[0].text.text).toBe("plain output")
+  })
+
+  it("reports a capped Pi read through structured truncation", () => {
+    const output = readEnvelope(["alpha", "beta"], CAPPED_FOOTER)
+    const result = buildTypedExecResult("pi_read_result", output, undefined, "read") as {
+      success: { output: string; truncation?: Record<string, unknown> }
+    }
+    expect(result.success.output).toBe("alpha\nbeta")
+    expect(result.success.truncation).toMatchObject({
+      truncated: true,
+      truncated_by: "bytes",
+      output_lines: 2,
+      max_bytes: 51200,
+    })
+  })
+
+  it("omits Pi truncation for a complete read", () => {
+    const output = readEnvelope(["alpha", "beta"], COMPLETE_FOOTER)
+    const result = buildTypedExecResult("pi_read_result", output, undefined, "read") as {
+      success: { truncation?: unknown }
+    }
+    expect(result.success.truncation).toBeUndefined()
+  })
+
+  it("round-trips PiReadExecSuccess.truncation on the wire", () => {
+    const encoded = encodeMessage("PiReadExecResult", {
+      success: {
+        output: "alpha",
+        truncation: { truncated: true, truncated_by: "bytes", output_lines: 1, max_bytes: 51200 },
+      },
+    })
+    const decoded = decodeMessage<{
+      success: { output: string; truncation: Record<string, unknown> }
+    }>("PiReadExecResult", encoded)
+    expect(decoded.success.output).toBe("alpha")
+    expect(decoded.success.truncation).toMatchObject({ truncated: true, max_bytes: 51200 })
+  })
+})
+
+describe("WriteArgs.file_bytes", () => {
+  it("prefers file_bytes over file_text, as Cursor's own executor does", () => {
+    const mapped = mapCursorArgsToOpencode("write", {
+      path: "a.txt",
+      file_text: "stale",
+      file_bytes: new TextEncoder().encode("from bytes"),
+    })
+    expect(mapped.args).toEqual({ filePath: "a.txt", content: "from bytes" })
+  })
+
+  it("falls back to file_text when file_bytes is empty", () => {
+    const mapped = mapCursorArgsToOpencode("write", {
+      path: "a.txt",
+      file_text: "from text",
+      file_bytes: new Uint8Array(0),
+    })
+    expect(mapped.args).toEqual({ filePath: "a.txt", content: "from text" })
+  })
+
+  it("decodes an encoding_hint other than utf-8", () => {
+    const mapped = mapCursorArgsToOpencode("write", {
+      path: "a.txt",
+      file_bytes: Uint8Array.from([0xe9, 0x74, 0x65]),
+      encoding_hint: "latin1",
+    })
+    expect(mapped.args.content).toBe("éte")
+  })
+
+  it("decodes as utf-8 when the hint is unsupported", () => {
+    const mapped = mapCursorArgsToOpencode("write", {
+      path: "a.txt",
+      file_bytes: new TextEncoder().encode("plain"),
+      encoding_hint: "not-a-real-encoding",
+    })
+    expect(mapped.args.content).toBe("plain")
+  })
+
+  it("decodes a byte-encoded write off the wire", () => {
+    const encoded = encodeMessage("WriteArgs", {
+      path: "a.txt",
+      file_bytes: new TextEncoder().encode("wire bytes"),
+    })
+    const decoded = decodeMessage<Record<string, unknown>>("WriteArgs", encoded)
+    const parsed = parseExecServerMessage({ id: 3, write_args: decoded })
+    expect(parsed?.toolName).toBe("write")
+    expect(parsed?.args).toMatchObject({ filePath: "a.txt", content: "wire bytes" })
+  })
+})

--- a/test/read-cap-repro.test.ts
+++ b/test/read-cap-repro.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "bun:test"
+import { buildTypedExecResult, unwrapReadOutput } from "../src/protocol/tools.js"
+
+/**
+ * Deterministic reproduction of the large-file data-loss chain reported as
+ * "writing large files truncates at ~50 KB".
+ *
+ * The truncation is on the READ, not the write. OpenCode's read tool caps
+ * output at `MAX_BYTES = 50 * 1024` (`packages/opencode/src/tool/read.ts:16`),
+ * cutting on a whole-line boundary, and appends a footer saying so. The
+ * provider strips the read envelope before handing content to Cursor — by
+ * design, so the model cannot echo wrappers into a later write — which used to
+ * discard that footer too. The model then believed a capped read was the whole
+ * file, rewrote it from what it had, and everything past the cap was lost.
+ *
+ * Cursor's own CLI caps identically (`local-exec` `const io = 51200`) but never
+ * silently: it annotates every capped payload and hands back a path to the full
+ * output. These tests pin both halves — the exact cap arithmetic, and the fact
+ * that the provider now re-states it.
+ */
+
+const MAX_BYTES = 50 * 1024
+
+/** Fixed-width fixture line: exactly 63 bytes, so the cut point is exact. */
+function fixtureLine(n: number): string {
+  const id = String(n).padStart(4, "0")
+  return `LINE ${id} ${".".repeat(44)} KEEP${id}`
+}
+
+/** ~75 KB fixture — same order of magnitude as the reported file. */
+function buildFixture(totalLines = 1200): string[] {
+  return Array.from({ length: totalLines }, (_, i) => fixtureLine(i + 1))
+}
+
+/**
+ * Byte-for-byte port of opencode's read accumulation loop
+ * (`tool/read.ts:162-173`) and its output envelope (`:338-351`).
+ */
+function opencodeRead(
+  allLines: string[],
+  filePath: string,
+  opts: { limit?: number; offset?: number } = {},
+): { output: string; keptLines: number; bytes: number } {
+  const limit = opts.limit ?? 2000
+  const offset = opts.offset ?? 1
+  const raw: string[] = []
+  let bytes = 0
+  let cut = false
+  let more = false
+
+  for (let i = offset - 1; i < allLines.length; i++) {
+    if (raw.length >= limit) {
+      more = true
+      break
+    }
+    const line = allLines[i]
+    const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+    if (bytes + size <= MAX_BYTES) {
+      raw.push(line)
+      bytes += size
+      continue
+    }
+    cut = true
+    more = true
+    break
+  }
+
+  let output = [`<path>${filePath}</path>`, `<type>file</type>`, "<content>\n"].join("\n")
+  output += raw.map((line, i) => `${i + offset}: ${line}`).join("\n")
+  const last = offset + raw.length - 1
+  const next = last + 1
+  if (cut) {
+    output += `\n\n(Output capped at 50 KB. Showing lines ${offset}-${last}. Use offset=${next} to continue.)`
+  } else if (more) {
+    output += `\n\n(Showing lines ${offset}-${last} of ${allLines.length}. Use offset=${next} to continue.)`
+  } else {
+    output += `\n\n(End of file - total ${allLines.length} lines)`
+  }
+  output += "\n</content>"
+  return { output, keptLines: raw.length, bytes }
+}
+
+describe("opencode read cap arithmetic", () => {
+  it("cuts a 75 KB fixture at exactly 800 lines / 51,199 bytes", () => {
+    const fixture = buildFixture(1200)
+    // 63 bytes per line, +1 for every newline after the first:
+    //   63 + 64*(n-1) = 64n - 1  ->  n = 800 gives 51,199 (<= 51,200)
+    //                                n = 801 gives 51,263 (>  51,200)
+    expect(Buffer.byteLength(fixture[0], "utf8")).toBe(63)
+    const { keptLines, bytes } = opencodeRead(fixture, "big.txt")
+    expect(keptLines).toBe(800)
+    expect(bytes).toBe(51_199)
+    expect(bytes).toBeLessThanOrEqual(MAX_BYTES)
+  })
+
+  it("lands just under the cap regardless of line width", () => {
+    // The reported captures were 51,144 and 51,167 bytes — different totals for
+    // different files, both under 51,200. That variation is the signature of a
+    // whole-line cut, not a fixed byte slice.
+    for (const width of [37, 63, 101, 250]) {
+      const lines = Array.from({ length: 4000 }, () => "x".repeat(width))
+      const { bytes } = opencodeRead(lines, "f.txt")
+      expect(bytes).toBeLessThanOrEqual(MAX_BYTES)
+      expect(bytes).toBeGreaterThan(MAX_BYTES - width - 1)
+    }
+  })
+
+  it("returns a file under the cap intact", () => {
+    // The reporter's 35.6 KB file survived; this is why.
+    const fixture = buildFixture(500)
+    const { output, keptLines } = opencodeRead(fixture, "small.txt")
+    expect(keptLines).toBe(500)
+    expect(output).toContain("(End of file - total 500 lines)")
+  })
+})
+
+describe("the data loss this causes", () => {
+  const fixture = buildFixture(1200)
+  const { output } = opencodeRead(fixture, "big.txt")
+
+  it("hands the model only the first 800 lines", () => {
+    const content = unwrapReadOutput(output)
+    const lines = content.split("\n")
+    expect(lines).toHaveLength(800)
+    expect(lines[0]).toBe(fixtureLine(1))
+    expect(lines[799]).toBe(fixtureLine(800))
+    // The tail the model never sees. A rewrite from this content deletes it.
+    expect(content).not.toContain("KEEP1200")
+    expect(fixture[1199]).toContain("KEEP1200")
+  })
+
+  it("strips the footer from the content stream", () => {
+    // Deliberate: anything left in the content is echoed back into the next
+    // write. The fix is to re-state the cap elsewhere, not to keep the footer.
+    const content = unwrapReadOutput(output)
+    expect(content).not.toContain("Output capped")
+    expect(content).not.toContain("<content>")
+  })
+})
+
+describe("the provider now reports the cap", () => {
+  const fixture = buildFixture(1200)
+  const capped = opencodeRead(fixture, "big.txt").output
+  const complete = opencodeRead(buildFixture(500), "small.txt").output
+
+  it("attaches a partial-read notice to a capped MCP read", () => {
+    const result = buildTypedExecResult("mcp_result", capped, undefined, "read") as {
+      success: { content: Array<{ text: { text: string } }> }
+    }
+    expect(result.success.content).toHaveLength(2)
+    // Content item stays byte-exact — still safe to echo into a write.
+    expect(result.success.content[0].text.text.split("\n")).toHaveLength(800)
+    const notice = result.success.content[1].text.text
+    expect(notice).toContain("NOT the complete file")
+    expect(notice).toContain("offset=801")
+    expect(notice).toContain("after line 800")
+  })
+
+  it("reports a capped Pi read structurally", () => {
+    const result = buildTypedExecResult("pi_read_result", capped, undefined, "read") as {
+      success: { truncation?: Record<string, unknown> }
+    }
+    expect(result.success.truncation).toMatchObject({
+      truncated: true,
+      truncated_by: "bytes",
+      output_lines: 800,
+      max_bytes: MAX_BYTES,
+    })
+  })
+
+  it("appends the notice to a capped native read_result", () => {
+    // This is the path live captures actually use: gpt-5.4-mini and grok-4.5
+    // both read through Cursor's native read_args, not mcp_args. The
+    // structured `truncated` flag alone did not stop models asserting that
+    // partial content was the whole file.
+    const result = buildTypedExecResult("read_result", capped, undefined, "read", {
+      path: "big.txt",
+    }) as { success: { content: string; truncated: boolean } }
+    expect(result.success.truncated).toBe(true)
+    expect(result.success.content).toContain("NOT the complete file")
+    expect(result.success.content.split("\n")[0]).toBe(fixtureLine(1))
+  })
+
+  it("does not cry wolf on a deliberately paged read", () => {
+    // An explicit offset/limit means the caller asked for a slice; only an
+    // involuntary cap warrants the warning.
+    const paged = opencodeRead(buildFixture(1200), "big.txt", { limit: 5 }).output
+    const result = buildTypedExecResult("read_result", paged, undefined, "read", {
+      path: "big.txt",
+      offset: 1,
+      limit: 5,
+    }) as { success: { content: string } }
+    expect(result.success.content).not.toContain("Partial read")
+  })
+
+  it("is not fooled by a file that quotes a read footer", () => {
+    // This repository's own README and tests contain that sentence. Scanning
+    // the whole envelope instead of just the footer would report a complete
+    // read as truncated.
+    const body = [
+      "1: The read tool prints:",
+      "2: (Output capped at 50 KB. Showing lines 1-2. Use offset=3 to continue.)",
+      "3: ...and that is the end.",
+    ].join("\n")
+    const output = [
+      "<path>doc.md</path>",
+      "<type>file</type>",
+      "<content>\n" + body,
+      "",
+      "(End of file - total 3 lines)",
+      "</content>",
+    ].join("\n")
+    const result = buildTypedExecResult("mcp_result", output, undefined, "read") as {
+      success: { content: unknown[] }
+    }
+    expect(result.success.content).toHaveLength(1)
+  })
+
+  it("stays silent for a complete read", () => {
+    const mcp = buildTypedExecResult("mcp_result", complete, undefined, "read") as {
+      success: { content: unknown[] }
+    }
+    expect(mcp.success.content).toHaveLength(1)
+    const pi = buildTypedExecResult("pi_read_result", complete, undefined, "read") as {
+      success: { truncation?: unknown }
+    }
+    expect(pi.success.truncation).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #18 — both faults.

## Fault A — `write`/`edit` unavailable on GPT models

OpenCode 1.x does not merely *add* `apply_patch` for GPT models; it **removes** `edit` and `write` from the catalog in exchange (`ToolRegistry.tools` — model id contains `gpt-` and neither `oss` nor `gpt-4`). Cursor keeps sending its native write/edit exec requests regardless, so every file change was refused as an unavailable tool.

`remapEditToolsForCatalog` translates those into `apply_patch` envelopes:

- whole-file write → `*** Add File:` (which overwrites, per opencode's own test *"adds file overwriting existing file"*, so no diff or existence check is needed)
- substring edit → `*** Update File:` with a minimal `@@` chunk, widened to whole lines because `apply_patch` matches line sequences while `edit` is substring-based

Unreadable, absent, ambiguous, or overlapping edits are refused with a specific message rather than patched into the wrong region. Source files above 50 MB are refused too, since the expansion read is synchronous on the Run pump.

Keyed **only** off the advertised tool set — never a model id or host version — so it is inert wherever `edit`/`write` are offered normally, and inert again on OpenCode 2.0, which has no such substitution.

Advertisement needed no change: `toolsToDescriptors` already forwards `opencode-apply_patch` to Cursor verbatim. Only the native exec channel was untranslated.

## Fault B — large files silently truncated at ~50 KB

**The truncation is on the read, not the write.** OpenCode's read tool caps at `MAX_BYTES = 50 * 1024`, cuts on a whole-line boundary, and appends `(Output capped at 50 KB. Showing lines X-Y. Use offset=N to continue.)`. `unwrapReadOutput` stripped that footer along with the envelope, so the model treated a capped read as the complete file and rewrote it — destroying everything past the cap.

That also explains the reporter's numbers: 51,144 and 51,167 bytes, both just under 51,200, differing because the line boundary falls differently per file; and the 35.6 KB file surviving intact.

The envelope is still stripped byte-for-byte — preventing wrappers being echoed into writes is why it exists — but the cap is now re-stated:

| path | signal |
|---|---|
| `read_result` (native) | `[Partial read: …]` marker appended after content |
| `mcp_result` | separate notice content item, content stays byte-exact |
| `pi_read_result` | structured `PiReadExecSuccess.truncation` |

Reads the caller bounded itself with an explicit `offset`/`limit` are not marked.

The structured `truncated` flag was **already** being sent on `read_result` and is not sufficient on its own — see the A/B below.

## Also

Decodes `WriteArgs.file_bytes` (#5) and `encoding_hint` (#6). The schema declared only fields 1–3, and an internal-keys filter discarded both. Cursor's own `LocalWriteExecutor` prefers bytes when non-empty, so a byte-encoded write would have decoded as empty content. Latent — never observed on the wire — but the schema now matches `agent.v1.WriteArgs`.

## Verification

`bun run typecheck`, `bun run build`, `bun test` — 658 pass / 0 fail. Three new test files, including a deterministic reproduction that ports opencode's read accumulation loop and pins the cut at exactly 800 lines / 51,199 bytes for a 63-byte-line fixture.

End-to-end against **OpenCode 1.18.9**:

- `cursor/gpt-5.4-mini` advertised `[apply_patch, bash, …]` — no `edit`, no `write`. `cursor/grok-4.5` advertised `edit` + `write` and no `apply_patch`. The gate, live, on both sides.
- gpt-5.4-mini edit succeeded: native exec with `resultField=write_result` remapped to `toolName=apply_patch`; a 1200-line whole-file reversal completed with all lines intact.
- Controlled A/B on a *blind* fixture (uniform lines, one unique token at the end, so the marker is the only possible signal):

| marker | gpt-5.4-mini |
|---|---|
| off | "does not contain `ZZZEND`. I'm **highly confident**" — confidently wrong |
| on | "confidence is **low** because the file output was **truncated**" |

grok-4.5-high, same probe: *"truncated by a 50 KB host limit and is not the complete file, so confidence is only moderate (~60%)"*.

## Known issue, not addressed here

grok-4.5's ~76 KB single `write` stalled and tripped the provider's own `Cursor semantic-progress timeout after 120000ms`. The file was left intact — no data loss — but the write never landed. That looks like a distinct third fault (large writes on the native channel stalling) and wants its own investigation; nobody should read this PR as proving large-file writes work end-to-end.

## Note on commit structure

Intended as two commits, one per fault, but the changes are interleaved within `tools.ts` and non-interactive hunk splitting was not available. Squashed into one rather than risk patch surgery.

Draft pending review.
