### PR TITLE
fix: preserve explicit variant parameters

### DIFF
--- a/src/language-model.ts
+++ b/src/language-model.ts
@@ -143,7 +143,7 @@ import {
   retrySuppressedError,
   toCursorProviderError,
 } from "./errors.js"
-import { readCache, cacheFilePath, resolveVariantParameters, paramsImplyMaxMode, extractCursorVariantParameters, resolveCursorWireModelId, type ModelInfo } from "./models.js"
+import { readCache, cacheFilePath, resolveVariantParameters, resolveVariantMaxMode, extractCursorVariantParameters, resolveCursorWireModelId, type ModelInfo } from "./models.js"
 import { getOrBuildRequestContext } from "./context/frozen.js"
 import { workspaceRootFromRequestContext } from "./context/env.js"
 import {
@@ -985,9 +985,12 @@ async function startSession(
     maxMode: hintMaxMode,
     picked,
   })
-  // Wire max_mode from the hint *or* a 1m context pick — OpenCode's variant
-  // paramMap does not include a maxMode key when the user selects 1m.
-  const maxMode = hintMaxMode || paramsImplyMaxMode(parameterValues)
+  // An explicit pick owns the context tier; otherwise honor the maxMode hint.
+  // OpenCode's variant paramMap does not include maxMode when the user selects 1m.
+  const maxMode = resolveVariantMaxMode(parameterValues, {
+    picked,
+    maxMode: hintMaxMode,
+  })
 
   // Do NOT pass callOptions.abortSignal into the h2 Run stream. OpenCode aborts
   // that signal when a turn ends with tool-calls; the Cursor stream must stay

--- a/src/models.ts
+++ b/src/models.ts
@@ -255,6 +255,17 @@ export function paramsImplyMaxMode(params: ModelParameterValue[]): boolean {
   )
 }
 
+/**
+ * Resolve the request-level max_mode bit. An explicit variant pick owns the
+ * context tier; otherwise a standalone maxMode hint may select max mode.
+ */
+export function resolveVariantMaxMode(
+  params: ModelParameterValue[],
+  opts: { picked?: ModelParameterValue[]; maxMode?: boolean } = {},
+): boolean {
+  return paramsImplyMaxMode(params) || (opts.picked === undefined && opts.maxMode === true)
+}
+
 // Cursor encodes a model's context window as a variant parameter `id: "context"`
 // whose value is a tier string — the same 200k / 272k / 300k / 1m the IDE's
 // picker shows. The base tier rides on the default non-max variant; the 1M
@@ -466,9 +477,7 @@ export function resolveVariantParameters(
         v.parameterValues.every((parameter) => pickedById.get(parameter.id) === parameter.value),
     )
     if (exact) {
-      return buildRequestedModelParams(exact.parameterValues, {
-        maxMode: wantMax,
-      })
+      return buildRequestedModelParams(exact.parameterValues)
     }
     throw new CursorVariantSelectionError(
       `is stale for model ${JSON.stringify(model.id)}: its exact parameter tuple is unavailable`,

--- a/src/models.ts
+++ b/src/models.ts
@@ -467,7 +467,6 @@ export function resolveVariantParameters(
     )
     if (exact) {
       return buildRequestedModelParams(exact.parameterValues, {
-        reasoningEffort: opts.reasoningEffort,
         maxMode: wantMax,
       })
     }

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -12,6 +12,7 @@ import {
   refreshModelCache,
   resolveVariantParameters,
   paramsImplyMaxMode,
+  resolveVariantMaxMode,
   extractCursorVariantParameters,
   writeCache,
   CURSOR_VARIANT_PARAMETERS_KEY,
@@ -613,6 +614,53 @@ describe("resolveVariantParameters (picked variant + max mode)", () => {
     expect(() => resolveVariantParameters(opus, { picked: [...valid, valid[0]!] })).toThrow(
       /exact parameter tuple/,
     )
+  })
+
+  it("does not let a reasoningEffort hint override an explicitly picked variant", () => {
+    const picked = [
+      { id: "context", value: "1m" },
+      { id: "effort", value: "high" },
+      { id: "fast", value: "false" },
+    ]
+    const params = resolveVariantParameters(opus, { picked, reasoningEffort: "medium" })
+    expect(params).toEqual(picked)
+  })
+
+  it("sets max mode for a picked 1m variant despite a false hint", () => {
+    const picked = [
+      { id: "context", value: "1m" },
+      { id: "effort", value: "low" },
+      { id: "fast", value: "false" },
+    ]
+    const params = resolveVariantParameters(opus, { picked, maxMode: false })
+    expect(resolveVariantMaxMode(params, { picked, maxMode: false })).toBe(true)
+  })
+
+  it("does not let a true maxMode hint override a picked base variant", () => {
+    const picked = [
+      { id: "context", value: "300k" },
+      { id: "effort", value: "high" },
+      { id: "fast", value: "false" },
+    ]
+    const params = resolveVariantParameters(opus, { picked, maxMode: true })
+    expect(params).toEqual(picked)
+    expect(resolveVariantMaxMode(params, { picked, maxMode: true })).toBe(false)
+  })
+
+  it("uses max and effort hints to select an unpicked 1m variant", () => {
+    const params = resolveVariantParameters(opus, {
+      reasoningEffort: "high",
+      maxMode: true,
+    })
+    expect(params.find((p) => p.id === "context")?.value).toBe("1m")
+    expect(params.find((p) => p.id === "effort")?.value).toBe("high")
+    expect(resolveVariantMaxMode(params, { maxMode: true })).toBe(true)
+  })
+
+  it("keeps an effort-only unpicked resolution out of max mode", () => {
+    const params = resolveVariantParameters(opus, { reasoningEffort: "high" })
+    expect(params.find((p) => p.id === "effort")?.value).toBe("high")
+    expect(resolveVariantMaxMode(params)).toBe(false)
   })
 })
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -193,11 +193,12 @@ describe("buildRunRequest", () => {
     expect(decoded.run_request.action.user_message_action.request_context?.tools ?? []).toHaveLength(0)
   })
 
-  it("includes parameter values when provided", () => {
+  it("includes parameter values and max mode when provided", () => {
     const data = buildRunRequest({
       text: "Hi",
       modelId: "test-model",
       conversationId: "conv-2",
+      maxMode: true,
       parameterValues: [
         { id: "effort", value: "high" },
         { id: "thinking", value: "true" },
@@ -209,6 +210,7 @@ describe("buildRunRequest", () => {
     expect(params).toHaveLength(2)
     expect(params[0].id).toBe("effort")
     expect(params[0].value).toBe("high")
+    expect(decoded.run_request.requested_model?.max_mode).toBe(true)
   })
 
   it("delivers system prompt via conversation_state, not custom_system_prompt", () => {


### PR DESCRIPTION
When a variant is explicitly selected, preserve its parameter tuple instead of applying a generic `reasoningEffort` hint. This prevents explicit selections such as Max from being silently changed to Medium.